### PR TITLE
fix directory of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/aotakeuma2/" # Location of package manifests
+    directory: "aotakeuma2/" # Location of package manifests
     schedule:
       interval: "weekly"
+    assignees:
+      - "Bmbo-sprg"


### PR DESCRIPTION
# 起きている問題

`/aotakeuma2` だけを見るつもりが、 `/aotakeuma` も見てしまってる

# 解決方法

知らんけど最初の `/` 消したら動くんかな