### PR TITLE
ブラウザネイティブのdateインプットをDatePickerInputに置き換え

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,12 @@
 pnpm-lock.yaml
+.claude/
+.bash_profile
+.bashrc
+.gitconfig
+.gitmodules
+.idea
+.mcp.json
+.profile
+.ripgreprc
+.zprofile
+.zshrc

--- a/app/components/DatePickerInput/DatePickerInput.stories.tsx
+++ b/app/components/DatePickerInput/DatePickerInput.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import { DatePickerInput } from "./DatePickerInput";
+
+const meta: Meta<typeof DatePickerInput> = {
+  title: "DatePickerInput",
+  component: DatePickerInput,
+};
+
+export default meta;
+type Story = StoryObj<typeof DatePickerInput>;
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState("");
+
+    return (
+      <div className="w-48">
+        <DatePickerInput value={value} onChange={setValue} />
+        <p className="mt-2 text-xs text-slate-500">
+          値: {value || "（未入力）"}
+        </p>
+      </div>
+    );
+  },
+};
+
+export const WithInitialValue: Story = {
+  render: () => {
+    const [value, setValue] = useState("2025-03-01");
+
+    return (
+      <div className="w-48">
+        <DatePickerInput value={value} onChange={setValue} />
+        <p className="mt-2 text-xs text-slate-500">
+          値: {value || "（未入力）"}
+        </p>
+      </div>
+    );
+  },
+};

--- a/app/components/DatePickerInput/DatePickerInput.tsx
+++ b/app/components/DatePickerInput/DatePickerInput.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from "react";
+import { DayPicker } from "react-day-picker";
+import { ja } from "react-day-picker/locale";
+
+type DatePickerInputProps = {
+  value?: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+};
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseDate(s: string): Date | undefined {
+  if (!DATE_RE.test(s)) return undefined;
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+function formatDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
+}
+
+// 数字のみ抽出し、4桁・6桁の区切りに「-」を自動挿入する
+function applyMask(raw: string): string {
+  const digits = raw.replace(/\D/g, "").slice(0, 8);
+  if (digits.length <= 4) return digits;
+  if (digits.length <= 6) return `${digits.slice(0, 4)}-${digits.slice(4)}`;
+  return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6)}`;
+}
+
+export const DatePickerInput = ({
+  value = "",
+  onChange,
+  placeholder = "yyyy-mm-dd",
+  className,
+}: DatePickerInputProps) => {
+  const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState(value);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // 外部からのリセット（フォームリセットなど）に追従する
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  // 外側クリックで閉じる
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") setOpen(false);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const masked = applyMask(e.target.value);
+    setInputValue(masked);
+    if (DATE_RE.test(masked)) {
+      onChange(masked);
+    } else if (masked === "") {
+      onChange("");
+    }
+  };
+
+  const handleDaySelect = (day: Date | undefined) => {
+    if (!day) return;
+    const formatted = formatDate(day);
+    setInputValue(formatted);
+    onChange(formatted);
+    setOpen(false);
+  };
+
+  const selected = parseDate(inputValue);
+  const month = selected ?? new Date();
+
+  return (
+    <div ref={containerRef} className="relative">
+      <input
+        type="text"
+        inputMode="numeric"
+        value={inputValue}
+        placeholder={placeholder}
+        className={[
+          "w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm",
+          "transition-colors duration-150 focus:border-slate-400 focus:outline-none",
+          className,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+        onChange={handleInputChange}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+      />
+      <div
+        className={[
+          "absolute left-0 top-full z-50 mt-1 rounded-md border border-slate-200 bg-white p-3 shadow-lg",
+          "transition-opacity duration-150",
+          open ? "opacity-100" : "opacity-0 pointer-events-none",
+        ].join(" ")}
+      >
+        <DayPicker
+          mode="single"
+          selected={selected}
+          defaultMonth={month}
+          onSelect={handleDaySelect}
+          locale={ja}
+          classNames={{
+            root: "text-sm text-slate-700",
+            month_caption:
+              "flex items-center mb-3 px-1 font-semibold text-slate-900",
+            nav: "flex items-center justify-between mb-3",
+            button_previous:
+              "rounded p-1 transition-colors duration-150 hover:bg-slate-100",
+            button_next:
+              "rounded p-1 transition-colors duration-150 hover:bg-slate-100",
+            chevron: "fill-slate-500 w-4 h-4",
+            month_grid: "w-full border-collapse",
+            weekdays: "",
+            weekday: "w-9 pb-2 text-center text-xs font-medium text-slate-400",
+            week: "",
+            day: "p-0 text-center",
+            day_button:
+              "w-9 h-9 rounded-full transition-colors duration-150 hover:bg-slate-100",
+            selected:
+              "[&>button]:bg-primary [&>button]:text-white [&>button]:hover:bg-primary",
+            today: "[&>button]:font-bold [&>button]:text-primary",
+            outside: "[&>button]:text-slate-300",
+            disabled: "[&>button]:text-slate-300 [&>button]:cursor-not-allowed",
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/app/routes/events/index.tsx
+++ b/app/routes/events/index.tsx
@@ -1,7 +1,8 @@
 import type { Event, Tag } from "~/types";
 import type { Route } from "./+types/index";
 import { useEffect, useMemo } from "react";
-import { useForm, useWatch } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
+import { DatePickerInput } from "../../components/DatePickerInput/DatePickerInput";
 import { events } from "../../contents/events";
 import { tags } from "../../contents/tags";
 import { normalizeText } from "../../utils/searches";
@@ -175,18 +176,28 @@ export function EventsView({
         <div className="grid gap-4 mb-0 sm:grid-cols-2">
           <div className="space-y-2">
             <label className="text-sm font-medium text-slate-700">From</label>
-            <input
-              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none"
-              type="date"
-              {...register("from")}
+            <Controller
+              control={control}
+              name="from"
+              render={({ field }) => (
+                <DatePickerInput
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
             />
           </div>
           <div className="space-y-2">
             <label className="text-sm font-medium text-slate-700">To</label>
-            <input
-              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none"
-              type="date"
-              {...register("to")}
+            <Controller
+              control={control}
+              name="to"
+              render={({ field }) => (
+                <DatePickerInput
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
             />
           </div>
         </div>

--- a/app/routes/works/index.tsx
+++ b/app/routes/works/index.tsx
@@ -1,7 +1,8 @@
 import type { Tag, Work } from "~/types";
 import type { Route } from "./+types/index";
 import { useEffect, useMemo } from "react";
-import { useForm, useWatch } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
+import { DatePickerInput } from "../../components/DatePickerInput/DatePickerInput";
 import { works } from "../../contents/works";
 import { tags } from "../../contents/tags";
 import { WorkCard } from "../../components/WorkCard/WorkCard";
@@ -162,18 +163,28 @@ export function WorksView({ filters }: { filters: WorkFilter }) {
         <div className="grid gap-4 mb-0 sm:grid-cols-2">
           <div className="space-y-2">
             <label className="text-sm font-medium text-slate-700">From</label>
-            <input
-              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none"
-              type="date"
-              {...register("from")}
+            <Controller
+              control={control}
+              name="from"
+              render={({ field }) => (
+                <DatePickerInput
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
             />
           </div>
           <div className="space-y-2">
             <label className="text-sm font-medium text-slate-700">To</label>
-            <input
-              className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none"
-              type="date"
-              {...register("to")}
+            <Controller
+              control={control}
+              name="to"
+              render={({ field }) => (
+                <DatePickerInput
+                  value={field.value}
+                  onChange={field.onChange}
+                />
+              )}
             />
           </div>
         </div>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "isbot": "^5.1.39",
     "react": "^19.2.5",
+    "react-day-picker": "^10.0.0",
     "react-dom": "^19.2.5",
     "react-hook-form": "^7.75.0",
     "react-router": "^7.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       react:
         specifier: ^19.2.5
         version: 19.2.5
+      react-day-picker:
+        specifier: ^10.0.0
+        version: 10.0.0(react@19.2.5)
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
@@ -572,6 +575,9 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@date-fns/tz@1.4.1':
+    resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -2403,6 +2409,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -3387,6 +3396,12 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  react-day-picker@10.0.0:
+    resolution: {integrity: sha512-lrEXo5wFPsq5LTcayelM3BPueD00v7zbdipAY+EIdPcseVykYwkOWx4Ujn/EtbBvpnp8ZPUHol17HXH6kVbZoA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
 
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
@@ -4818,6 +4833,8 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@date-fns/tz@1.4.1': {}
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -6544,6 +6561,8 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  date-fns@4.1.0: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -7651,6 +7670,12 @@ snapshots:
       react-is: 16.13.1
 
   punycode@2.3.1: {}
+
+  react-day-picker@10.0.0(react@19.2.5):
+    dependencies:
+      '@date-fns/tz': 1.4.1
+      date-fns: 4.1.0
+      react: 19.2.5
 
   react-docgen-typescript@2.4.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

- `react-day-picker` を使った `DatePickerInput` コンポーネントを新規作成
- テキスト入力時に `yyyy-mm-dd` 形式でハイフンを自動挿入（PCユーザーの直接入力に対応）
- カレンダーは日本語ロケール・Tailwindスタイリング・150msフェードイン/アウトアニメーション付き
- `/works` と `/events` のフィルターフォームで `<input type="date">` を置き換え（Safari対応）
- `DatePickerInput.stories.tsx` を追加
- `.prettierignore` にサンドボックス環境のdotfilesを追加

## Test plan

- [ ] `/works` の From/To フィールドでカレンダーが開閉することを確認
- [ ] `/events` の From/To フィールドでカレンダーが開閉することを確認
- [ ] テキスト直接入力時にハイフンが自動挿入されることを確認
- [ ] 日付を選択するとフィルターが機能することを確認
- [ ] Safari で動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)