### PR TITLE
フィルター状態を URL クエリパラメータで管理し react-hook-form を削除

### DIFF
--- a/app/components/DownloadSection/DownloadSection.tsx
+++ b/app/components/DownloadSection/DownloadSection.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState, type ChangeEvent } from "react";
-import { Controller, useForm } from "react-hook-form";
 import { DownloadKey } from "../../utils/DownloadKey";
 
 const DEBOUNCE_MS = 700;
@@ -29,12 +28,7 @@ export function DownloadSection({
   title = "ダウンロード",
   description = "ダウンロードカード裏面に記載されたダウンロードコードをここに入力してください。",
 }: DownloadSectionProps) {
-  const { control, handleSubmit, setValue } = useForm<{ downloadKey: string }>({
-    defaultValues: {
-      downloadKey: "",
-    },
-  });
-
+  const [downloadKey, setDownloadKey] = useState("");
   const [verifyStatus, setVerifyStatus] = useState<VerifyStatus>("idle");
   const [verifyMessage, setVerifyMessage] = useState("");
   const [downloadUrl, setDownloadUrl] = useState("");
@@ -126,19 +120,16 @@ export function DownloadSection({
       setDownloadUrl("");
     }
 
-    setValue("downloadKey", displayKey, {
-      shouldDirty: true,
-      shouldTouch: true,
-      shouldValidate: false,
-    });
+    setDownloadKey(displayKey);
   };
 
-  const onSubmit = handleSubmit(() => {
+  const onSubmit = (e: React.SubmitEvent<HTMLFormElement>) => {
+    e.preventDefault();
     if (verifyStatus !== "verified" || !downloadUrl) {
       return;
     }
     window.location.assign(downloadUrl);
-  });
+  };
 
   const inputId = `downloadKey-${productId}`;
   const statusId = `${inputId}-status`;
@@ -162,29 +153,21 @@ export function DownloadSection({
           >
             ダウンロードコード
           </label>
-          <Controller
+          <input
+            type="text"
+            id={inputId}
             name="downloadKey"
-            control={control}
-            render={({ field }) => (
-              <input
-                type="text"
-                id={inputId}
-                name={field.name}
-                value={field.value}
-                onBlur={field.onBlur}
-                ref={field.ref}
-                onChange={onChangeDownloadKey}
-                className={[
-                  "w-full px-4 py-2 rounded-lg border border-slate-300 bg-white text-slate-900 placeholder-slate-400",
-                  "focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20",
-                  "transition-all duration-150",
-                ].join(" ")}
-                placeholder="ダウンロードコードを入力してください"
-                autoComplete="off"
-                inputMode="text"
-                aria-describedby={statusId}
-              />
-            )}
+            value={downloadKey}
+            onChange={onChangeDownloadKey}
+            className={[
+              "w-full px-4 py-2 rounded-lg border border-slate-300 bg-white text-slate-900 placeholder-slate-400",
+              "focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20",
+              "transition-all duration-150",
+            ].join(" ")}
+            placeholder="ダウンロードコードを入力してください"
+            autoComplete="off"
+            inputMode="text"
+            aria-describedby={statusId}
           />
 
           <div id={statusId} className="min-h-6">

--- a/app/routes/events/index.tsx
+++ b/app/routes/events/index.tsx
@@ -1,7 +1,7 @@
 import type { Event, Tag } from "~/types";
 import type { Route } from "./+types/index";
-import { useEffect, useMemo } from "react";
-import { Controller, useForm, useWatch } from "react-hook-form";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
 import { DatePickerInput } from "../../components/DatePickerInput/DatePickerInput";
 import { events } from "../../contents/events";
 import { tags } from "../../contents/tags";
@@ -73,6 +73,8 @@ export function loader({ request }: Route.LoaderArgs) {
   };
 }
 
+const DEBOUNCE_MS = 300;
+
 export function EventsView({
   filters,
   now,
@@ -80,40 +82,48 @@ export function EventsView({
   filters: EventFilter;
   now: Date;
 }) {
-  const { register, control, setValue } = useForm<EventFilter>({
-    defaultValues: {
-      query: filters.query,
-      type: filters.type,
-      tag: filters.tag,
-      from: filters.from,
-      to: filters.to,
-      sort: filters.sort,
-    },
-  });
-  const watchedValues = useWatch({ control });
-  const filteredEvents = useMemo(() => {
-    return filterEvents(events, {
-      query: watchedValues.query ?? "",
-      type: watchedValues.type ?? "",
-      tag: watchedValues.tag ?? "",
-      from: watchedValues.from ?? "",
-      to: watchedValues.to ?? "",
-      sort: watchedValues.sort ?? "new",
-    });
-  }, [watchedValues]);
+  const [, setSearchParams] = useSearchParams();
+  const [queryInput, setQueryInput] = useState(filters.query);
+  const debounceRef = useRef<number | null>(null);
 
   useEffect(() => {
-    setValue("query", filters.query, { shouldDirty: false });
-    setValue("type", filters.type, { shouldDirty: false });
-    setValue("tag", filters.tag, { shouldDirty: false });
-    setValue("from", filters.from, { shouldDirty: false });
-    setValue("to", filters.to, { shouldDirty: false });
-    setValue("sort", filters.sort, { shouldDirty: false });
-  }, [filters, setValue]);
+    return () => {
+      if (debounceRef.current !== null)
+        window.clearTimeout(debounceRef.current);
+    };
+  }, []);
 
-  const activeType = watchedValues.type;
-  const activeTag = watchedValues.tag;
-  const activeSort = watchedValues.sort;
+  const updateParam = (key: string, value: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (value) {
+          next.set(key, value);
+        } else {
+          next.delete(key);
+        }
+        return next;
+      },
+      { replace: true }
+    );
+  };
+
+  const handleQueryChange = (value: string) => {
+    setQueryInput(value);
+    if (debounceRef.current !== null) window.clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(() => {
+      updateParam("query", value);
+    }, DEBOUNCE_MS);
+  };
+
+  const filteredEvents = useMemo(
+    () => filterEvents(events, filters),
+    [filters]
+  );
+
+  const activeType = filters.type;
+  const activeTag = filters.tag;
+  const activeSort = filters.sort;
 
   return (
     <main className="space-y-8 p-6">
@@ -121,9 +131,7 @@ export function EventsView({
         <h1 className="text-2xl font-semibold text-slate-900">イベント</h1>
         <Toggle
           value={activeSort}
-          onChange={(nextValue) =>
-            setValue("sort", nextValue as SortOrder, { shouldDirty: true })
-          }
+          onChange={(nextValue) => updateParam("sort", nextValue)}
           left={{ value: "new", label: "新しい順" }}
           right={{ value: "old", label: "古い順" }}
         />
@@ -136,7 +144,8 @@ export function EventsView({
             className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none"
             placeholder="イベント名で検索"
             type="text"
-            {...register("query")}
+            value={queryInput}
+            onChange={(e) => handleQueryChange(e.target.value)}
           />
         </div>
 
@@ -144,11 +153,7 @@ export function EventsView({
           <label className="text-sm font-medium text-slate-700">タイプ</label>
           <BadgeButtonList
             value={activeType}
-            onChange={(value) =>
-              setValue("type", value as Event["type"] | "", {
-                shouldDirty: true,
-              })
-            }
+            onChange={(value) => updateParam("type", value)}
             options={[
               { value: "", label: "すべて" },
               { value: "exhibition", label: "即売会" },
@@ -161,11 +166,7 @@ export function EventsView({
           <label className="text-sm font-medium text-slate-700">タグ</label>
           <BadgeButtonList
             value={activeTag}
-            onChange={(value) =>
-              setValue("tag", value, {
-                shouldDirty: true,
-              })
-            }
+            onChange={(value) => updateParam("tag", value)}
             options={[
               { value: "", label: "すべて" },
               ...tags.map((tag) => ({ value: tag, label: tag })),
@@ -176,35 +177,19 @@ export function EventsView({
         <div className="grid gap-4 mb-0 sm:grid-cols-2">
           <div className="space-y-2">
             <label className="text-sm font-medium text-slate-700">From</label>
-            <Controller
-              control={control}
-              name="from"
-              render={({ field }) => (
-                <DatePickerInput
-                  value={field.value}
-                  onChange={field.onChange}
-                />
-              )}
+            <DatePickerInput
+              value={filters.from}
+              onChange={(value) => updateParam("from", value)}
             />
           </div>
           <div className="space-y-2">
             <label className="text-sm font-medium text-slate-700">To</label>
-            <Controller
-              control={control}
-              name="to"
-              render={({ field }) => (
-                <DatePickerInput
-                  value={field.value}
-                  onChange={field.onChange}
-                />
-              )}
+            <DatePickerInput
+              value={filters.to}
+              onChange={(value) => updateParam("to", value)}
             />
           </div>
         </div>
-
-        <input type="hidden" {...register("type")} />
-        <input type="hidden" {...register("tag")} />
-        <input type="hidden" {...register("sort")} />
       </form>
 
       <p className="text-sm text-slate-700">

--- a/app/routes/works/index.tsx
+++ b/app/routes/works/index.tsx
@@ -1,7 +1,7 @@
 import type { Tag, Work } from "~/types";
 import type { Route } from "./+types/index";
-import { useEffect, useMemo } from "react";
-import { Controller, useForm, useWatch } from "react-hook-form";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router";
 import { DatePickerInput } from "../../components/DatePickerInput/DatePickerInput";
 import { works } from "../../contents/works";
 import { tags } from "../../contents/tags";
@@ -73,43 +73,52 @@ export function loader({ request }: Route.LoaderArgs) {
   };
 }
 
+const DEBOUNCE_MS = 300;
+
 export function WorksView({ filters }: { filters: WorkFilter }) {
-  const { register, control, setValue } = useForm<WorkFilter>();
-  const watchedValues = useWatch({ control });
-
-  const activeType = watchedValues.type;
-  const activeTag = watchedValues.tag;
-  const activeSort = watchedValues.sort;
-
-  const filteredWorks = useMemo(() => {
-    return filterWorks(works, {
-      query: watchedValues.query ?? "",
-      type: activeType ?? "",
-      tag: activeTag ?? "",
-      from: watchedValues.from ?? "",
-      to: watchedValues.to ?? "",
-      sort: activeSort ?? "new",
-    });
-  }, [watchedValues, activeType, activeTag, activeSort]);
+  const [, setSearchParams] = useSearchParams();
+  const [queryInput, setQueryInput] = useState(filters.query);
+  const debounceRef = useRef<number | null>(null);
 
   useEffect(() => {
-    setValue("query", filters.query, { shouldDirty: false });
-    setValue("type", filters.type, { shouldDirty: false });
-    setValue("tag", filters.tag, { shouldDirty: false });
-    setValue("from", filters.from, { shouldDirty: false });
-    setValue("to", filters.to, { shouldDirty: false });
-    setValue("sort", filters.sort, { shouldDirty: false });
-  }, [filters, setValue]);
+    return () => {
+      if (debounceRef.current !== null)
+        window.clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const updateParam = (key: string, value: string) => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (value) {
+          next.set(key, value);
+        } else {
+          next.delete(key);
+        }
+        return next;
+      },
+      { replace: true }
+    );
+  };
+
+  const handleQueryChange = (value: string) => {
+    setQueryInput(value);
+    if (debounceRef.current !== null) window.clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(() => {
+      updateParam("query", value);
+    }, DEBOUNCE_MS);
+  };
+
+  const filteredWorks = useMemo(() => filterWorks(works, filters), [filters]);
 
   return (
     <main className="space-y-8 p-6 lg:max-w-4xl lg:mx-auto">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <h1 className="text-2xl font-semibold text-slate-900">作品</h1>
         <Toggle
-          value={activeSort}
-          onChange={(nextValue) =>
-            setValue("sort", nextValue as SortOrder, { shouldDirty: true })
-          }
+          value={filters.sort}
+          onChange={(nextValue) => updateParam("sort", nextValue)}
           left={{ value: "new", label: "新しい順" }}
           right={{ value: "old", label: "古い順" }}
         />
@@ -122,19 +131,16 @@ export function WorksView({ filters }: { filters: WorkFilter }) {
             className="w-full rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none"
             placeholder="作品名で検索"
             type="text"
-            {...register("query")}
+            value={queryInput}
+            onChange={(e) => handleQueryChange(e.target.value)}
           />
         </div>
 
         <div>
           <label className="text-sm font-medium text-slate-700">タイプ</label>
           <BadgeButtonList
-            value={activeType}
-            onChange={(value) =>
-              setValue("type", value as Work["type"] | "", {
-                shouldDirty: true,
-              })
-            }
+            value={filters.type}
+            onChange={(value) => updateParam("type", value)}
             options={[
               { value: "", label: "すべて" },
               { value: "album", label: "アルバム" },
@@ -147,12 +153,8 @@ export function WorksView({ filters }: { filters: WorkFilter }) {
         <div>
           <label className="text-sm font-medium text-slate-700">タグ</label>
           <BadgeButtonList
-            value={activeTag}
-            onChange={(value) =>
-              setValue("tag", value, {
-                shouldDirty: true,
-              })
-            }
+            value={filters.tag}
+            onChange={(value) => updateParam("tag", value)}
             options={[
               { value: "", label: "すべて" },
               ...tags.map((tag) => ({ value: tag, label: tag })),
@@ -163,35 +165,19 @@ export function WorksView({ filters }: { filters: WorkFilter }) {
         <div className="grid gap-4 mb-0 sm:grid-cols-2">
           <div className="space-y-2">
             <label className="text-sm font-medium text-slate-700">From</label>
-            <Controller
-              control={control}
-              name="from"
-              render={({ field }) => (
-                <DatePickerInput
-                  value={field.value}
-                  onChange={field.onChange}
-                />
-              )}
+            <DatePickerInput
+              value={filters.from}
+              onChange={(value) => updateParam("from", value)}
             />
           </div>
           <div className="space-y-2">
             <label className="text-sm font-medium text-slate-700">To</label>
-            <Controller
-              control={control}
-              name="to"
-              render={({ field }) => (
-                <DatePickerInput
-                  value={field.value}
-                  onChange={field.onChange}
-                />
-              )}
+            <DatePickerInput
+              value={filters.to}
+              onChange={(value) => updateParam("to", value)}
             />
           </div>
         </div>
-
-        <input type="hidden" {...register("type")} />
-        <input type="hidden" {...register("tag")} />
-        <input type="hidden" {...register("sort")} />
       </form>
 
       <p className="text-sm text-slate-700">{filteredWorks.length}件の作品</p>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "react": "^19.2.5",
     "react-day-picker": "^10.0.0",
     "react-dom": "^19.2.5",
-    "react-hook-form": "^7.75.0",
     "react-router": "^7.12.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.5(react@19.2.5)
-      react-hook-form:
-        specifier: ^7.75.0
-        version: 7.75.0(react@19.2.5)
       react-router:
         specifier: ^7.12.0
         version: 7.12.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -3416,12 +3413,6 @@ packages:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
-
-  react-hook-form@7.75.0:
-    resolution: {integrity: sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-inspector@9.0.0:
     resolution: {integrity: sha512-w/VJucSeHxlwRa2nfM2k7YhpT1r5EtlDOClSR+L7DyQP91QMdfFEDXDs9bPYN4kzP7umFtom7L0b2GGjph4Kow==}
@@ -7700,10 +7691,6 @@ snapshots:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
-
-  react-hook-form@7.75.0(react@19.2.5):
-    dependencies:
-      react: 19.2.5
 
   react-inspector@9.0.0(react@19.2.5):
     dependencies:


### PR DESCRIPTION
## 変更内容

- 作品・イベント一覧ページのフィルター状態を URL クエリパラメータで管理するように変更
  - 詳細ページから戻ったときにフィルターが復元されるように
  - テキスト入力は 300ms デバウンス、バッジ/トグルは即時 URL 更新
- `DownloadSection` の `react-hook-form` 依存を `useState` に置き換え
- `react-hook-form` パッケージを削除

## 動作確認

- [ ] 作品一覧でフィルターを設定 → 詳細ページへ → 戻るでフィルターが復元される
- [ ] イベント一覧で同様に確認
- [ ] ダウンロードコード入力が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)