### PR TITLE
詳細ページに「一覧に戻る」ボタンを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Personal artist website for **竹馬あお** (aotakeuma.com). A React Router v7 SSR app running on Cloudflare Workers, with a signed download feature backed by Cloudflare R2 and KV.
 
-> The `aotakeuma2/` directory is a legacy build artifact from before the repo restructure. Do not edit it.
-
 ## Commands
 
 ```bash
@@ -70,6 +68,8 @@ Routes are explicitly declared in `app/routes.ts` (not filesystem-based). The `:
 ### Storybook
 
 Every component in `app/components/` has a colocated `.stories.tsx`. Route files in `app/routes/` also have stories — these use `storybook-addon-remix-react-router` to simulate the router context.
+
+**新しいコンポーネントを追加する際は、必ず同階層に `.stories.tsx` も作成すること。**
 
 ### Cloudflare bindings
 

--- a/app/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/app/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,27 +1,25 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { Breadcrumb } from "./Breadcrumb";
+import { BackButton } from "./Breadcrumb";
 
-const meta: Meta<typeof Breadcrumb> = {
-  title: "Breadcrumb",
-  component: Breadcrumb,
+const meta: Meta<typeof BackButton> = {
+  title: "BackButton",
+  component: BackButton,
 };
 
 export default meta;
-type Story = StoryObj<typeof Breadcrumb>;
+type Story = StoryObj<typeof BackButton>;
 
 export const Works: Story = {
   args: {
-    parentLabel: "作品一覧",
-    parentHref: "/works",
-    currentLabel: "夜光",
+    label: "作品一覧",
+    href: "/works",
   },
 };
 
 export const Events: Story = {
   args: {
-    parentLabel: "イベント一覧",
-    parentHref: "/events",
-    currentLabel: "M3-2025春",
+    label: "イベント一覧",
+    href: "/events",
   },
 };

--- a/app/components/Breadcrumb/Breadcrumb.stories.tsx
+++ b/app/components/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Breadcrumb } from "./Breadcrumb";
+
+const meta: Meta<typeof Breadcrumb> = {
+  title: "Breadcrumb",
+  component: Breadcrumb,
+};
+
+export default meta;
+type Story = StoryObj<typeof Breadcrumb>;
+
+export const Works: Story = {
+  args: {
+    parentLabel: "作品一覧",
+    parentHref: "/works",
+    currentLabel: "夜光",
+  },
+};
+
+export const Events: Story = {
+  args: {
+    parentLabel: "イベント一覧",
+    parentHref: "/events",
+    currentLabel: "M3-2025春",
+  },
+};

--- a/app/components/Breadcrumb/Breadcrumb.tsx
+++ b/app/components/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,33 @@
+import { Link } from "react-router";
+
+type BreadcrumbProps = {
+  parentLabel: string;
+  parentHref: string;
+  currentLabel: string;
+};
+
+export const Breadcrumb = ({
+  parentLabel,
+  parentHref,
+  currentLabel,
+}: BreadcrumbProps) => {
+  return (
+    <nav aria-label="パンくずリスト">
+      <ol className="flex items-center gap-1.5 text-sm text-slate-500 flex-wrap">
+        <li>
+          <Link
+            to={parentHref}
+            className="flex items-center gap-1 text-slate-600 underline underline-offset-2 hover:text-slate-900 transition-colors"
+          >
+            <span aria-hidden="true">←</span>
+            {parentLabel}
+          </Link>
+        </li>
+        <li aria-hidden="true">›</li>
+        <li className="truncate" aria-current="page">
+          {currentLabel}
+        </li>
+      </ol>
+    </nav>
+  );
+};

--- a/app/components/Breadcrumb/Breadcrumb.tsx
+++ b/app/components/Breadcrumb/Breadcrumb.tsx
@@ -1,33 +1,18 @@
 import { Link } from "react-router";
 
-type BreadcrumbProps = {
-  parentLabel: string;
-  parentHref: string;
-  currentLabel: string;
+type BackButtonProps = {
+  label: string;
+  href: string;
 };
 
-export const Breadcrumb = ({
-  parentLabel,
-  parentHref,
-  currentLabel,
-}: BreadcrumbProps) => {
+export const BackButton = ({ label, href }: BackButtonProps) => {
   return (
-    <nav aria-label="パンくずリスト">
-      <ol className="flex items-center gap-1.5 text-sm text-slate-500 flex-wrap">
-        <li>
-          <Link
-            to={parentHref}
-            className="flex items-center gap-1 text-slate-600 underline underline-offset-2 hover:text-slate-900 transition-colors"
-          >
-            <span aria-hidden="true">←</span>
-            {parentLabel}
-          </Link>
-        </li>
-        <li aria-hidden="true">›</li>
-        <li className="truncate" aria-current="page">
-          {currentLabel}
-        </li>
-      </ol>
-    </nav>
+    <Link
+      to={href}
+      className="inline-flex items-center gap-1 rounded-full border border-slate-300 px-3 py-1 text-sm font-semibold text-slate-700 shadow-sm bg-white/80 hover:bg-slate-50 transition-colors"
+    >
+      <span aria-hidden="true">←</span>
+      {label}
+    </Link>
   );
 };

--- a/app/components/EventHeadSection/EventHeadSection.tsx
+++ b/app/components/EventHeadSection/EventHeadSection.tsx
@@ -4,14 +4,12 @@ import { TagList } from "../TagList/TagList";
 import { SocialLinkList } from "../SocialLinkList/SocialLinkList";
 
 type EventHeadSectionProps = {
-  prefix: "即売会" | "DJ／ライブ" | "その他イベント";
   event: Event;
 };
 
-export const EventHeadSection = ({ prefix, event }: EventHeadSectionProps) => {
+export const EventHeadSection = ({ event }: EventHeadSectionProps) => {
   return (
     <section>
-      <p className="text-sm font-medium text-slate-500 -mb-1">{prefix}</p>
       <div className="flex flex-wrap items-center gap-2">
         <h1 className="text-2xl font-semibold text-slate-900">{event.title}</h1>
         <TagList tags={event.tags} />

--- a/app/routes/events/exhibition.tsx
+++ b/app/routes/events/exhibition.tsx
@@ -1,6 +1,7 @@
 import type { Exhibition } from "~/types";
 import type { Route } from "./+types/exhibition";
 import { exhibitions } from "../../contents/events/exhibitions";
+import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
 import { EventHeadSection } from "../../components/EventHeadSection/EventHeadSection";
 import { EventDescriptionSection } from "../../components/EventDescriptionSection/EventDescriptionSection";
 import { WorkCard } from "../../components/WorkCard/WorkCard";
@@ -25,6 +26,11 @@ export function loader({ params }: Route.LoaderArgs) {
 export function ExhibitionView({ event }: { event: Exhibition }) {
   return (
     <main className="space-y-8 p-6">
+      <Breadcrumb
+        parentLabel="イベント一覧"
+        parentHref="/events"
+        currentLabel={event.title}
+      />
       <EventHeadSection prefix="即売会" event={event} />
       <EventDescriptionSection description={event.description} />
       <section className="space-y-3">

--- a/app/routes/events/exhibition.tsx
+++ b/app/routes/events/exhibition.tsx
@@ -26,7 +26,7 @@ export function loader({ params }: Route.LoaderArgs) {
 export function ExhibitionView({ event }: { event: Exhibition }) {
   return (
     <main className="space-y-8 p-6">
-      <BackButton label="イベント一覧" href="/events" />
+      <BackButton label="即売会一覧へ" href="/events?type=exhibition" />
       <EventHeadSection prefix="即売会" event={event} />
       <EventDescriptionSection description={event.description} />
       <section className="space-y-3">

--- a/app/routes/events/exhibition.tsx
+++ b/app/routes/events/exhibition.tsx
@@ -1,7 +1,7 @@
 import type { Exhibition } from "~/types";
 import type { Route } from "./+types/exhibition";
 import { exhibitions } from "../../contents/events/exhibitions";
-import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
+import { BackButton } from "../../components/Breadcrumb/Breadcrumb";
 import { EventHeadSection } from "../../components/EventHeadSection/EventHeadSection";
 import { EventDescriptionSection } from "../../components/EventDescriptionSection/EventDescriptionSection";
 import { WorkCard } from "../../components/WorkCard/WorkCard";
@@ -26,11 +26,7 @@ export function loader({ params }: Route.LoaderArgs) {
 export function ExhibitionView({ event }: { event: Exhibition }) {
   return (
     <main className="space-y-8 p-6">
-      <Breadcrumb
-        parentLabel="イベント一覧"
-        parentHref="/events"
-        currentLabel={event.title}
-      />
+      <BackButton label="イベント一覧" href="/events" />
       <EventHeadSection prefix="即売会" event={event} />
       <EventDescriptionSection description={event.description} />
       <section className="space-y-3">

--- a/app/routes/events/exhibition.tsx
+++ b/app/routes/events/exhibition.tsx
@@ -27,7 +27,7 @@ export function ExhibitionView({ event }: { event: Exhibition }) {
   return (
     <main className="space-y-8 p-6">
       <BackButton label="即売会一覧へ" href="/events?type=exhibition" />
-      <EventHeadSection prefix="即売会" event={event} />
+      <EventHeadSection event={event} />
       <EventDescriptionSection description={event.description} />
       <section className="space-y-3">
         <h2 className="text-lg font-semibold text-slate-900">頒布物</h2>

--- a/app/routes/events/otherEvent.tsx
+++ b/app/routes/events/otherEvent.tsx
@@ -1,6 +1,7 @@
 import type { Event } from "~/types";
 import type { Route } from "./+types/otherEvent";
 import { events } from "../../contents/events";
+import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
 import { EventHeadSection } from "../../components/EventHeadSection/EventHeadSection";
 import { EventDescriptionSection } from "../../components/EventDescriptionSection/EventDescriptionSection";
 import { buildOGMeta, getEventPath } from "../../utils/paths";
@@ -24,6 +25,11 @@ export function loader({ params }: Route.LoaderArgs) {
 export function OtherEventView({ event }: { event: Event }) {
   return (
     <main className="space-y-8 p-6">
+      <Breadcrumb
+        parentLabel="イベント一覧"
+        parentHref="/events"
+        currentLabel={event.title}
+      />
       <EventHeadSection prefix="その他イベント" event={event} />
       <EventDescriptionSection description={event.description} />
     </main>

--- a/app/routes/events/otherEvent.tsx
+++ b/app/routes/events/otherEvent.tsx
@@ -25,7 +25,7 @@ export function loader({ params }: Route.LoaderArgs) {
 export function OtherEventView({ event }: { event: Event }) {
   return (
     <main className="space-y-8 p-6">
-      <BackButton label="イベント一覧" href="/events" />
+      <BackButton label="イベント一覧へ" href="/events" />
       <EventHeadSection prefix="その他イベント" event={event} />
       <EventDescriptionSection description={event.description} />
     </main>

--- a/app/routes/events/otherEvent.tsx
+++ b/app/routes/events/otherEvent.tsx
@@ -26,7 +26,7 @@ export function OtherEventView({ event }: { event: Event }) {
   return (
     <main className="space-y-8 p-6">
       <BackButton label="イベント一覧へ" href="/events" />
-      <EventHeadSection prefix="その他イベント" event={event} />
+      <EventHeadSection event={event} />
       <EventDescriptionSection description={event.description} />
     </main>
   );

--- a/app/routes/events/otherEvent.tsx
+++ b/app/routes/events/otherEvent.tsx
@@ -1,7 +1,7 @@
 import type { Event } from "~/types";
 import type { Route } from "./+types/otherEvent";
 import { events } from "../../contents/events";
-import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
+import { BackButton } from "../../components/Breadcrumb/Breadcrumb";
 import { EventHeadSection } from "../../components/EventHeadSection/EventHeadSection";
 import { EventDescriptionSection } from "../../components/EventDescriptionSection/EventDescriptionSection";
 import { buildOGMeta, getEventPath } from "../../utils/paths";
@@ -25,11 +25,7 @@ export function loader({ params }: Route.LoaderArgs) {
 export function OtherEventView({ event }: { event: Event }) {
   return (
     <main className="space-y-8 p-6">
-      <Breadcrumb
-        parentLabel="イベント一覧"
-        parentHref="/events"
-        currentLabel={event.title}
-      />
+      <BackButton label="イベント一覧" href="/events" />
       <EventHeadSection prefix="その他イベント" event={event} />
       <EventDescriptionSection description={event.description} />
     </main>

--- a/app/routes/events/performance.tsx
+++ b/app/routes/events/performance.tsx
@@ -1,6 +1,7 @@
 import type { Performance, SocialLink } from "~/types";
 import type { Route } from "./+types/performance";
 import { performances } from "../../contents/events/performances";
+import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
 import { EventHeadSection } from "../../components/EventHeadSection/EventHeadSection";
 import { EventDescriptionSection } from "../../components/EventDescriptionSection/EventDescriptionSection";
 import { MixcloudIframe } from "../../components/MixcloudIframe/MixcloudIframe";
@@ -26,6 +27,11 @@ export function loader({ params }: Route.LoaderArgs) {
 export function PerformanceView({ event }: { event: Performance }) {
   return (
     <main className="space-y-8 p-6">
+      <Breadcrumb
+        parentLabel="イベント一覧"
+        parentHref="/events"
+        currentLabel={event.title}
+      />
       <EventHeadSection prefix="DJ／ライブ" event={event} />
       <SocialLinkList
         links={

--- a/app/routes/events/performance.tsx
+++ b/app/routes/events/performance.tsx
@@ -1,7 +1,7 @@
 import type { Performance, SocialLink } from "~/types";
 import type { Route } from "./+types/performance";
 import { performances } from "../../contents/events/performances";
-import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
+import { BackButton } from "../../components/Breadcrumb/Breadcrumb";
 import { EventHeadSection } from "../../components/EventHeadSection/EventHeadSection";
 import { EventDescriptionSection } from "../../components/EventDescriptionSection/EventDescriptionSection";
 import { MixcloudIframe } from "../../components/MixcloudIframe/MixcloudIframe";
@@ -27,11 +27,7 @@ export function loader({ params }: Route.LoaderArgs) {
 export function PerformanceView({ event }: { event: Performance }) {
   return (
     <main className="space-y-8 p-6">
-      <Breadcrumb
-        parentLabel="イベント一覧"
-        parentHref="/events"
-        currentLabel={event.title}
-      />
+      <BackButton label="イベント一覧" href="/events" />
       <EventHeadSection prefix="DJ／ライブ" event={event} />
       <SocialLinkList
         links={

--- a/app/routes/events/performance.tsx
+++ b/app/routes/events/performance.tsx
@@ -28,7 +28,7 @@ export function PerformanceView({ event }: { event: Performance }) {
   return (
     <main className="space-y-8 p-6">
       <BackButton label="DJ／ライブ一覧へ" href="/events?type=performance" />
-      <EventHeadSection prefix="DJ／ライブ" event={event} />
+      <EventHeadSection event={event} />
       <SocialLinkList
         links={
           [...(event.links ?? []), event.detailLink, event.twitterLink].filter(

--- a/app/routes/events/performance.tsx
+++ b/app/routes/events/performance.tsx
@@ -27,7 +27,7 @@ export function loader({ params }: Route.LoaderArgs) {
 export function PerformanceView({ event }: { event: Performance }) {
   return (
     <main className="space-y-8 p-6">
-      <BackButton label="イベント一覧" href="/events" />
+      <BackButton label="DJ／ライブ一覧へ" href="/events?type=performance" />
       <EventHeadSection prefix="DJ／ライブ" event={event} />
       <SocialLinkList
         links={

--- a/app/routes/works/album.tsx
+++ b/app/routes/works/album.tsx
@@ -49,9 +49,11 @@ export function AlbumView({ album, now }: { album: Album; now: Date }) {
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
         <BackButton label="アルバム一覧へ" href="/works?type=album" />
         <section>
-          <p className="text-sm font-medium text-slate-500 -mb-1">
-            {album.titlePrefix ?? "アルバム"}
-          </p>
+          {album.titlePrefix && (
+            <p className="text-sm font-medium text-slate-500 -mb-1">
+              {album.titlePrefix}
+            </p>
+          )}
           <div className="flex flex-wrap items-center gap-2">
             <h1 className="text-2xl font-semibold text-slate-900">
               {album.title}

--- a/app/routes/works/album.tsx
+++ b/app/routes/works/album.tsx
@@ -4,6 +4,7 @@ import { exhibitions } from "../../contents/events/exhibitions";
 import { albums } from "../../contents/works/albums";
 import { AccordionSection } from "../../components/AccordionSection/AccordionSection";
 import { Banner } from "../../components/Banner/Banner";
+import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
 import { CreditCardList } from "../../components/CreditCardList/CreditCardList";
 import { DownloadSection } from "../../components/DownloadSection/DownloadSection";
 import { EventCard } from "../../components/EventCard/EventCard";
@@ -46,6 +47,11 @@ export function AlbumView({ album, now }: { album: Album; now: Date }) {
       <Banner src={album.jacketImageUrl} alt={`${album.title}のジャケット`} />
 
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
+        <Breadcrumb
+          parentLabel="作品一覧"
+          parentHref="/works"
+          currentLabel={album.title}
+        />
         <section>
           <p className="text-sm font-medium text-slate-500 -mb-1">
             {album.titlePrefix ?? "アルバム"}

--- a/app/routes/works/album.tsx
+++ b/app/routes/works/album.tsx
@@ -4,7 +4,7 @@ import { exhibitions } from "../../contents/events/exhibitions";
 import { albums } from "../../contents/works/albums";
 import { AccordionSection } from "../../components/AccordionSection/AccordionSection";
 import { Banner } from "../../components/Banner/Banner";
-import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
+import { BackButton } from "../../components/Breadcrumb/Breadcrumb";
 import { CreditCardList } from "../../components/CreditCardList/CreditCardList";
 import { DownloadSection } from "../../components/DownloadSection/DownloadSection";
 import { EventCard } from "../../components/EventCard/EventCard";
@@ -47,11 +47,7 @@ export function AlbumView({ album, now }: { album: Album; now: Date }) {
       <Banner src={album.jacketImageUrl} alt={`${album.title}のジャケット`} />
 
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
-        <Breadcrumb
-          parentLabel="作品一覧"
-          parentHref="/works"
-          currentLabel={album.title}
-        />
+        <BackButton label="作品一覧" href="/works" />
         <section>
           <p className="text-sm font-medium text-slate-500 -mb-1">
             {album.titlePrefix ?? "アルバム"}

--- a/app/routes/works/album.tsx
+++ b/app/routes/works/album.tsx
@@ -47,7 +47,7 @@ export function AlbumView({ album, now }: { album: Album; now: Date }) {
       <Banner src={album.jacketImageUrl} alt={`${album.title}のジャケット`} />
 
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
-        <BackButton label="作品一覧" href="/works" />
+        <BackButton label="アルバム一覧へ" href="/works?type=album" />
         <section>
           <p className="text-sm font-medium text-slate-500 -mb-1">
             {album.titlePrefix ?? "アルバム"}

--- a/app/routes/works/game.tsx
+++ b/app/routes/works/game.tsx
@@ -4,7 +4,7 @@ import { exhibitions } from "../../contents/events/exhibitions";
 import { games } from "../../contents/works/games";
 import { AccordionSection } from "../../components/AccordionSection/AccordionSection";
 import { Banner } from "../../components/Banner/Banner";
-import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
+import { BackButton } from "../../components/Breadcrumb/Breadcrumb";
 import { CreditCardList } from "../../components/CreditCardList/CreditCardList";
 import { EventCard } from "../../components/EventCard/EventCard";
 import { SocialLinkItem } from "../../components/SocialLinkItem/SocialLinkItem";
@@ -41,11 +41,7 @@ export function GameView({ game, now }: { game: Game; now: Date }) {
       <Banner src={game.jacketImageUrl} alt={`${game.title}のジャケット`} />
 
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
-        <Breadcrumb
-          parentLabel="作品一覧"
-          parentHref="/works"
-          currentLabel={game.title}
-        />
+        <BackButton label="作品一覧" href="/works" />
         <section>
           <p className="text-sm font-medium text-slate-500 -mb-1">ゲーム</p>
           <div className="flex flex-wrap items-center gap-2">

--- a/app/routes/works/game.tsx
+++ b/app/routes/works/game.tsx
@@ -4,6 +4,7 @@ import { exhibitions } from "../../contents/events/exhibitions";
 import { games } from "../../contents/works/games";
 import { AccordionSection } from "../../components/AccordionSection/AccordionSection";
 import { Banner } from "../../components/Banner/Banner";
+import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
 import { CreditCardList } from "../../components/CreditCardList/CreditCardList";
 import { EventCard } from "../../components/EventCard/EventCard";
 import { SocialLinkItem } from "../../components/SocialLinkItem/SocialLinkItem";
@@ -40,6 +41,11 @@ export function GameView({ game, now }: { game: Game; now: Date }) {
       <Banner src={game.jacketImageUrl} alt={`${game.title}のジャケット`} />
 
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
+        <Breadcrumb
+          parentLabel="作品一覧"
+          parentHref="/works"
+          currentLabel={game.title}
+        />
         <section>
           <p className="text-sm font-medium text-slate-500 -mb-1">ゲーム</p>
           <div className="flex flex-wrap items-center gap-2">

--- a/app/routes/works/game.tsx
+++ b/app/routes/works/game.tsx
@@ -43,7 +43,6 @@ export function GameView({ game, now }: { game: Game; now: Date }) {
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
         <BackButton label="ゲーム一覧へ" href="/works?type=game" />
         <section>
-          <p className="text-sm font-medium text-slate-500 -mb-1">ゲーム</p>
           <div className="flex flex-wrap items-center gap-2">
             <h1 className="text-2xl font-semibold text-slate-900">
               {game.title}

--- a/app/routes/works/game.tsx
+++ b/app/routes/works/game.tsx
@@ -41,7 +41,7 @@ export function GameView({ game, now }: { game: Game; now: Date }) {
       <Banner src={game.jacketImageUrl} alt={`${game.title}のジャケット`} />
 
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
-        <BackButton label="作品一覧" href="/works" />
+        <BackButton label="ゲーム一覧へ" href="/works?type=game" />
         <section>
           <p className="text-sm font-medium text-slate-500 -mb-1">ゲーム</p>
           <div className="flex flex-wrap items-center gap-2">

--- a/app/routes/works/music.tsx
+++ b/app/routes/works/music.tsx
@@ -68,7 +68,7 @@ export function MusicView({ music }: { music: Music }) {
       <Banner src={getBannerPath(music)} alt={`${music.title}のジャケット`} />
 
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
-        <BackButton label="作品一覧" href="/works" />
+        <BackButton label="音楽一覧へ" href="/works?type=music" />
         <section>
           <p className="text-sm font-medium text-slate-500 -mb-1">音楽</p>
           <div className="flex flex-wrap items-center gap-2">

--- a/app/routes/works/music.tsx
+++ b/app/routes/works/music.tsx
@@ -3,6 +3,7 @@ import type { Route } from "./+types/music";
 import { musics } from "../../contents/works/musics";
 import { albums } from "../../contents/works/albums";
 import { Banner } from "../../components/Banner/Banner";
+import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
 import { CreditCardList } from "../../components/CreditCardList/CreditCardList";
 import { SocialLinkItem } from "../../components/SocialLinkItem/SocialLinkItem";
 import { SpotifyIframe } from "../../components/SpotifyIframe/SpotifyIframe";
@@ -67,6 +68,11 @@ export function MusicView({ music }: { music: Music }) {
       <Banner src={getBannerPath(music)} alt={`${music.title}のジャケット`} />
 
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
+        <Breadcrumb
+          parentLabel="作品一覧"
+          parentHref="/works"
+          currentLabel={music.title}
+        />
         <section>
           <p className="text-sm font-medium text-slate-500 -mb-1">音楽</p>
           <div className="flex flex-wrap items-center gap-2">

--- a/app/routes/works/music.tsx
+++ b/app/routes/works/music.tsx
@@ -3,7 +3,7 @@ import type { Route } from "./+types/music";
 import { musics } from "../../contents/works/musics";
 import { albums } from "../../contents/works/albums";
 import { Banner } from "../../components/Banner/Banner";
-import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
+import { BackButton } from "../../components/Breadcrumb/Breadcrumb";
 import { CreditCardList } from "../../components/CreditCardList/CreditCardList";
 import { SocialLinkItem } from "../../components/SocialLinkItem/SocialLinkItem";
 import { SpotifyIframe } from "../../components/SpotifyIframe/SpotifyIframe";
@@ -68,11 +68,7 @@ export function MusicView({ music }: { music: Music }) {
       <Banner src={getBannerPath(music)} alt={`${music.title}のジャケット`} />
 
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
-        <Breadcrumb
-          parentLabel="作品一覧"
-          parentHref="/works"
-          currentLabel={music.title}
-        />
+        <BackButton label="作品一覧" href="/works" />
         <section>
           <p className="text-sm font-medium text-slate-500 -mb-1">音楽</p>
           <div className="flex flex-wrap items-center gap-2">

--- a/app/routes/works/music.tsx
+++ b/app/routes/works/music.tsx
@@ -70,7 +70,6 @@ export function MusicView({ music }: { music: Music }) {
       <div className="space-y-8 px-6 py-8 lg:max-w-4xl lg:mx-auto">
         <BackButton label="音楽一覧へ" href="/works?type=music" />
         <section>
-          <p className="text-sm font-medium text-slate-500 -mb-1">音楽</p>
           <div className="flex flex-wrap items-center gap-2">
             <h1 className="text-2xl font-semibold text-slate-900">
               {music.title}

--- a/app/routes/works/otherWork.tsx
+++ b/app/routes/works/otherWork.tsx
@@ -30,7 +30,6 @@ export function OtherWorkView({ work }: { work: Work }) {
     <main className="space-y-8 p-6 lg:max-w-4xl lg:mx-auto">
       <BackButton label="作品一覧へ" href="/works" />
       <section>
-        <p className="text-sm font-medium text-slate-500 -mb-1">その他作品</p>
         <div className="flex flex-wrap items-center gap-2">
           <h1 className="text-2xl font-semibold text-slate-900">
             {work.title}

--- a/app/routes/works/otherWork.tsx
+++ b/app/routes/works/otherWork.tsx
@@ -1,7 +1,7 @@
 import type { Work } from "~/types";
 import type { Route } from "./+types/otherWork";
 import { works } from "../../contents/works";
-import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
+import { BackButton } from "../../components/Breadcrumb/Breadcrumb";
 import { CreditCardList } from "../../components/CreditCardList/CreditCardList";
 import { SocialLinkItem } from "../../components/SocialLinkItem/SocialLinkItem";
 import { SpotifyIframe } from "../../components/SpotifyIframe/SpotifyIframe";
@@ -28,11 +28,7 @@ export function loader({ params }: Route.LoaderArgs) {
 export function OtherWorkView({ work }: { work: Work }) {
   return (
     <main className="space-y-8 p-6 lg:max-w-4xl lg:mx-auto">
-      <Breadcrumb
-        parentLabel="作品一覧"
-        parentHref="/works"
-        currentLabel={work.title}
-      />
+      <BackButton label="作品一覧" href="/works" />
       <section>
         <p className="text-sm font-medium text-slate-500 -mb-1">その他作品</p>
         <div className="flex flex-wrap items-center gap-2">

--- a/app/routes/works/otherWork.tsx
+++ b/app/routes/works/otherWork.tsx
@@ -28,7 +28,7 @@ export function loader({ params }: Route.LoaderArgs) {
 export function OtherWorkView({ work }: { work: Work }) {
   return (
     <main className="space-y-8 p-6 lg:max-w-4xl lg:mx-auto">
-      <BackButton label="作品一覧" href="/works" />
+      <BackButton label="作品一覧へ" href="/works" />
       <section>
         <p className="text-sm font-medium text-slate-500 -mb-1">その他作品</p>
         <div className="flex flex-wrap items-center gap-2">

--- a/app/routes/works/otherWork.tsx
+++ b/app/routes/works/otherWork.tsx
@@ -1,6 +1,7 @@
 import type { Work } from "~/types";
 import type { Route } from "./+types/otherWork";
 import { works } from "../../contents/works";
+import { Breadcrumb } from "../../components/Breadcrumb/Breadcrumb";
 import { CreditCardList } from "../../components/CreditCardList/CreditCardList";
 import { SocialLinkItem } from "../../components/SocialLinkItem/SocialLinkItem";
 import { SpotifyIframe } from "../../components/SpotifyIframe/SpotifyIframe";
@@ -27,6 +28,11 @@ export function loader({ params }: Route.LoaderArgs) {
 export function OtherWorkView({ work }: { work: Work }) {
   return (
     <main className="space-y-8 p-6 lg:max-w-4xl lg:mx-auto">
+      <Breadcrumb
+        parentLabel="作品一覧"
+        parentHref="/works"
+        currentLabel={work.title}
+      />
       <section>
         <p className="text-sm font-medium text-slate-500 -mb-1">その他作品</p>
         <div className="flex flex-wrap items-center gap-2">


### PR DESCRIPTION
## Summary

- 作品・イベントの詳細ページにバッジスタイルの「一覧に戻る」ボタン（`BackButton` コンポーネント）を追加
- ボタンはサブジャンルでフィルタリングされた一覧ページへ遷移（例: アルバム詳細 → `/works?type=album`）
- 「その他」カテゴリはフィルタなしの一覧ページへ遷移（既存の検索UIに「その他」フィルタがないため）
- Storybook も追加、CLAUDE.md にコンポーネント追加時のStorybookルールを明記

## Test plan

- [x] アルバム詳細ページで「← アルバム一覧へ」が表示され、クリックで `/works?type=album` に遷移
- [x] 音楽・ゲーム詳細も同様に各フィルタ付き一覧へ遷移
- [x] その他作品詳細で「← 作品一覧へ」が表示され、`/works` に遷移（フィルタなし）
- [x] イベント系（DJ／ライブ、即売会、その他）も同様に確認
- [x] Storybook で BackButton コンポーネントが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)