### PR TITLE
最終更新日を GitHub API から取得する方式に変更

### DIFF
--- a/app/env.d.ts
+++ b/app/env.d.ts
@@ -1,7 +1,1 @@
-declare global {
-  interface Env {
-    LAST_DEPLOYED_AT?: string;
-  }
-}
-
 export {};

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -24,15 +24,15 @@ export function meta(_: Route.MetaArgs) {
 
 export function loader({ context }: Route.LoaderArgs) {
   return {
-    lastDeployedAt: context.cloudflare.env.LAST_DEPLOYED_AT || null,
+    lastCommitAt: context.lastCommitAt,
     seed: Date.now(),
     now: new Date(),
   };
 }
 
 export default function Home({ loaderData }: Route.ComponentProps) {
-  const lastUpdatedDate = loaderData.lastDeployedAt
-    ? new Date(loaderData.lastDeployedAt)
+  const lastUpdatedDate = loaderData.lastCommitAt
+    ? new Date(loaderData.lastCommitAt)
     : null;
   const lastUpdatedText =
     lastUpdatedDate !== null && !Number.isNaN(lastUpdatedDate.getTime())
@@ -85,7 +85,9 @@ export default function Home({ loaderData }: Route.ComponentProps) {
               <p className="text-sm text-slate-700 font-semibold">
                 即売会出展・DJ 出演などをしてます
               </p>
-              <p className="text-xs text-slate-500">声音文脈 など所属</p>
+              <p className="text-xs text-slate-500">
+                声音文脈, 秘密結社D.D.D.D. など所属
+              </p>
             </Link>
           </div>
           <SocialLinkList

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -96,7 +96,16 @@ export default function Home({ loaderData }: Route.ComponentProps) {
           />
           {lastUpdatedText ? (
             <p className="text-xs text-slate-500">
-              最終更新日: {lastUpdatedText} 更新されてなかったら急かしてね！
+              最終更新日:{" "}
+              <a
+                href="https://github.com/Bmbo-sprg/aotakeuma/commits/main"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                {lastUpdatedText}
+              </a>{" "}
+              更新されてなかったら急かしてね！
             </p>
           ) : null}
         </div>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "pnpm run typegen && react-router dev",
     "build": "pnpm run typegen && react-router build",
     "preview": "pnpm run build && vite preview",
-    "deploy": "pnpm run build && wrangler deploy --var LAST_DEPLOYED_AT:$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+    "deploy": "pnpm run build && wrangler deploy",
     "lint": "prettier . --check && eslint",
     "fix": "prettier . --write && eslint --fix",
     "postinstall": "pnpm run typegen",

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -1,5 +1,6 @@
-import { createRequestHandler } from "react-router";
+import { createRequestHandler, type AppLoadContext } from "react-router";
 import { handleSignedDownload, handleValidateKey } from "./download/handlers";
+import { fetchLastCommitAt } from "./github";
 
 declare module "react-router" {
   export interface AppLoadContext {
@@ -7,7 +8,18 @@ declare module "react-router" {
       env: Env;
       ctx: ExecutionContext;
     };
+    lastCommitAt: string | null;
   }
+}
+
+async function buildAppLoadContext(
+  env: Env,
+  ctx: ExecutionContext
+): Promise<AppLoadContext> {
+  return {
+    cloudflare: { env, ctx },
+    lastCommitAt: await fetchLastCommitAt(),
+  };
 }
 
 const requestHandler = createRequestHandler(
@@ -34,9 +46,10 @@ export default {
       return handleSignedDownload(request, env);
     }
 
-    const response = await requestHandler(request, {
-      cloudflare: { env, ctx },
-    });
+    const response = await requestHandler(
+      request,
+      await buildAppLoadContext(env, ctx)
+    );
 
     if (url.pathname.startsWith("/yohkoh")) {
       const blocked = new Response(response.body, response);

--- a/workers/github.ts
+++ b/workers/github.ts
@@ -1,0 +1,30 @@
+const GITHUB_COMMITS_API =
+  "https://api.github.com/repos/Bmbo-sprg/aotakeuma/commits/main";
+const CACHE_TTL_SECONDS = 60 * 60 * 24; // 24時間
+
+export async function fetchLastCommitAt(): Promise<string | null> {
+  const cache = await caches.open("github-last-commit");
+  const cached = await cache.match(GITHUB_COMMITS_API);
+  if (cached) {
+    return cached.text();
+  }
+
+  try {
+    const res = await fetch(GITHUB_COMMITS_API, {
+      headers: { "User-Agent": "aotakeuma-worker" },
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      commit: { committer: { date: string } };
+    };
+    const date = data.commit.committer.date;
+
+    const cacheRes = new Response(date, {
+      headers: { "Cache-Control": `max-age=${CACHE_TTL_SECONDS}` },
+    });
+    await cache.put(GITHUB_COMMITS_API, cacheRes);
+    return date;
+  } catch {
+    return null;
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,9 +7,6 @@
   "name": "aotakeuma2", // aotakeuma は古い SPA 版
   "compatibility_date": "2025-04-04",
   "main": "./workers/app.ts",
-  "vars": {
-    "LAST_DEPLOYED_AT": "",
-  },
   "observability": {
     "enabled": true,
   },


### PR DESCRIPTION
## Summary

- デプロイ時環境変数 `LAST_DEPLOYED_AT` を廃止し、GitHub API（public リポジトリ）から main ブランチの最新コミット日時を取得する方式に変更
- Cloudflare Cache API で TTL 24時間キャッシュ、取得失敗時は日付欄を非表示（現行挙動と同じ）
- 最終更新日テキストを GitHub commits ページへのリンクに変更
- GitHub API ロジックを `workers/github.ts` に分離、`buildAppLoadContext()` でコンテキスト構築を明示化

Closes #84

## Test plan

- [x] ローカルで `pnpm dev` して最終更新日が表示されることを確認
- [x] 日付をクリックして `https://github.com/Bmbo-sprg/aotakeuma/commits/main` に遷移することを確認
- [x] デプロイ後、`LAST_DEPLOYED_AT` を wrangler から設定しなくても日付が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)