### PR TITLE
refactor: dev 専用ロジックをミドルウェアに切り出し & コメント整理

### DIFF
--- a/workers/api/router.ts
+++ b/workers/api/router.ts
@@ -7,6 +7,7 @@ const api = new Hono<{ Bindings: Env }>().basePath("/api");
 api.post("/validate-key", validateKey);
 api.get("/download", signedDownload);
 
+// admin API は production ビルドに含めない (そのための動的 import)
 if (import.meta.env.DEV) {
   const { adminRouter } = await import("./admin/router");
   api.route("/admin", adminRouter);

--- a/workers/app.ts
+++ b/workers/app.ts
@@ -1,6 +1,7 @@
 import { createRequestHandler, type AppLoadContext } from "react-router";
 import { fetchLastCommitAt } from "./lastCommit";
 import { api } from "./api/router";
+import { fixDevOrigin } from "./middleware/fixDevOrigin";
 
 declare module "react-router" {
   export interface AppLoadContext {
@@ -32,21 +33,15 @@ export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
 
+    // API ルートへのリクエストは Hono で処理
     if (url.pathname.startsWith("/api/")) {
       return api.fetch(request, env, ctx);
     }
 
-    // wrangler dev --remote では Origin と Host が食い違い React Router の CSRF チェックで弾かれるため修正
-    if (import.meta.env.DEV) {
-      const host = request.headers.get("host");
-      const origin = request.headers.get("origin");
-      if (host && origin && new URL(origin).host !== host) {
-        const headers = new Headers(request.headers);
-        headers.set("origin", `${new URL(origin).protocol}//${host}`);
-        request = new Request(request, { headers });
-      }
-    }
-
-    return requestHandler(request, await buildAppLoadContext(env, ctx));
+    // API ルート以外は React Router で処理
+    return requestHandler(
+      fixDevOrigin(request),
+      await buildAppLoadContext(env, ctx)
+    );
   },
 } satisfies ExportedHandler<Env>;

--- a/workers/middleware/fixDevOrigin.ts
+++ b/workers/middleware/fixDevOrigin.ts
@@ -1,0 +1,15 @@
+/**
+ * wrangler dev --remote では Origin と Host が食い違い React Router の CSRF チェックで
+ * 弾かれるため、開発環境のみ Origin ヘッダーを Host に合わせて書き換える
+ */
+export function fixDevOrigin(request: Request): Request {
+  if (!import.meta.env.DEV) return request;
+
+  const host = request.headers.get("host");
+  const origin = request.headers.get("origin");
+  if (!host || !origin || new URL(origin).host === host) return request;
+
+  const headers = new Headers(request.headers);
+  headers.set("origin", `${new URL(origin).protocol}//${host}`);
+  return new Request(request, { headers });
+}


### PR DESCRIPTION
## Summary

- `workers/app.ts` に直書きされていた Origin 書き換え処理を `workers/middleware/fixDevOrigin.ts` に切り出し
- `workers/api/router.ts` の動的 import に、production ビルド除外のための意図を示すコメントを追加

Closes #143

## Test plan

- [ ] `pnpm build` が通ること（CI で確認）
- [ ] `pnpm dev:remote` で `/admin` フォーム送信が CSRF エラーなく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)