### PR TITLE
test: unit テスト・stories を追加（issue #129）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,13 @@ pnpm build            # production build（admin ルート・API を除外）
 pnpm lint             # prettier + eslint check
 pnpm fix              # prettier + eslint autofix
 pnpm storybook        # Storybook dev server (port 6006)
+pnpm test             # vitest run（app/ および workers/ 以下の *.test.ts）
 
 # typegen (run after changing wrangler.jsonc or adding routes)
 pnpm typegen
 ```
 
-Tests use Vitest and run via Storybook's addon-vitest. There is no standalone `pnpm test` script — run tests through Storybook or check `*.test.ts` files with `vitest` directly.
+`pnpm test` は `app/` と `workers/` 以下の `*.test.ts` を実行する。Storybook の addon-vitest は stories に紐付いたインタラクションテスト用。
 
 **Deploy**: GitHub Actions が main push 時に自動デプロイ。手動: `pnpm deploy`。
 

--- a/app/components/DatePickerInput/DatePickerInput.tsx
+++ b/app/components/DatePickerInput/DatePickerInput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { DayPicker } from "react-day-picker";
 import { ja } from "react-day-picker/locale";
+import { applyMask, DATE_RE, formatDate, parseDate } from "./dateUtils";
 
 type DatePickerInputProps = {
   value?: string;
@@ -8,29 +9,6 @@ type DatePickerInputProps = {
   placeholder?: string;
   className?: string;
 };
-
-const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-
-function parseDate(s: string): Date | undefined {
-  if (!DATE_RE.test(s)) return undefined;
-  const d = new Date(s);
-  return isNaN(d.getTime()) ? undefined : d;
-}
-
-function formatDate(d: Date): string {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${dd}`;
-}
-
-// 数字のみ抽出し、4桁・6桁の区切りに「-」を自動挿入する
-function applyMask(raw: string): string {
-  const digits = raw.replace(/\D/g, "").slice(0, 8);
-  if (digits.length <= 4) return digits;
-  if (digits.length <= 6) return `${digits.slice(0, 4)}-${digits.slice(4)}`;
-  return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6)}`;
-}
 
 export const DatePickerInput = ({
   value = "",

--- a/app/components/DatePickerInput/dateUtils.test.ts
+++ b/app/components/DatePickerInput/dateUtils.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { applyMask, formatDate, parseDate } from "./dateUtils";
+
+describe("parseDate", () => {
+  it("有効な日付文字列をパースする", () => {
+    const d = parseDate("2025-03-15");
+    expect(d).toBeInstanceOf(Date);
+    expect(d?.getFullYear()).toBe(2025);
+    expect(d?.getMonth()).toBe(2); // 0-indexed
+    expect(d?.getDate()).toBe(15);
+  });
+
+  it("形式が不正な文字列は undefined を返す", () => {
+    expect(parseDate("2025/03/15")).toBeUndefined();
+    expect(parseDate("20250315")).toBeUndefined();
+    expect(parseDate("")).toBeUndefined();
+    expect(parseDate("abc")).toBeUndefined();
+  });
+
+  it("存在しない日付は undefined を返す", () => {
+    expect(parseDate("2025-13-01")).toBeUndefined();
+    expect(parseDate("2025-00-01")).toBeUndefined();
+  });
+});
+
+describe("formatDate", () => {
+  it("Date を yyyy-mm-dd 形式にフォーマットする", () => {
+    expect(formatDate(new Date("2025-03-05"))).toBe("2025-03-05");
+    expect(formatDate(new Date("2025-12-31"))).toBe("2025-12-31");
+    expect(formatDate(new Date("2025-01-01"))).toBe("2025-01-01");
+  });
+
+  it("月・日が1桁のときゼロパディングされる", () => {
+    expect(formatDate(new Date("2025-03-05"))).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("applyMask", () => {
+  it("4桁以下はそのまま返す", () => {
+    expect(applyMask("2025")).toBe("2025");
+    expect(applyMask("202")).toBe("202");
+  });
+
+  it("5〜6桁は yyyy-mm 形式にする", () => {
+    expect(applyMask("202503")).toBe("2025-03");
+    expect(applyMask("20253")).toBe("2025-3");
+  });
+
+  it("7〜8桁は yyyy-mm-dd 形式にする", () => {
+    expect(applyMask("20250315")).toBe("2025-03-15");
+    expect(applyMask("2025031")).toBe("2025-03-1");
+  });
+
+  it("数字以外の文字を除去する", () => {
+    expect(applyMask("2025/03/15")).toBe("2025-03-15");
+    expect(applyMask("2025-03-15")).toBe("2025-03-15");
+  });
+
+  it("8桁を超える入力は切り捨てる", () => {
+    expect(applyMask("202503150000")).toBe("2025-03-15");
+  });
+});

--- a/app/components/DatePickerInput/dateUtils.ts
+++ b/app/components/DatePickerInput/dateUtils.ts
@@ -1,0 +1,24 @@
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function parseDate(s: string): Date | undefined {
+  if (!DATE_RE.test(s)) return undefined;
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+export function formatDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${dd}`;
+}
+
+// 数字のみ抽出し、4桁・6桁の区切りに「-」を自動挿入する
+export function applyMask(raw: string): string {
+  const digits = raw.replace(/\D/g, "").slice(0, 8);
+  if (digits.length <= 4) return digits;
+  if (digits.length <= 6) return `${digits.slice(0, 4)}-${digits.slice(4)}`;
+  return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6)}`;
+}
+
+export { DATE_RE };

--- a/app/components/DownloadSection/DownloadSection.stories.tsx
+++ b/app/components/DownloadSection/DownloadSection.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+import { DownloadSection } from "./DownloadSection";
+import type { ValidateApiResponse } from "./DownloadSection";
+
+const meta: Meta<typeof DownloadSection> = {
+  title: "DownloadSection",
+  component: DownloadSection,
+  args: {
+    validateKey: fn(),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DownloadSection>;
+
+export const Default: Story = {
+  args: {
+    productId: "sample_album",
+  },
+};
+
+export const Verified: Story = {
+  args: {
+    productId: "sample_album",
+    validateKey: fn().mockResolvedValue({
+      ok: true,
+      key: "ABCD-1234",
+      productId: "sample_album",
+      downloadUrl: "https://example.com/download",
+    } satisfies ValidateApiResponse),
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    productId: "sample_album",
+    validateKey: fn().mockResolvedValue({
+      ok: false,
+      reason: "not_found",
+      message: "このコードは存在しません。",
+    } satisfies ValidateApiResponse),
+  },
+};

--- a/app/components/DownloadSection/DownloadSection.stories.tsx
+++ b/app/components/DownloadSection/DownloadSection.stories.tsx
@@ -23,22 +23,26 @@ export const Default: Story = {
 export const Verified: Story = {
   args: {
     productId: "sample_album",
-    validateKey: fn().mockResolvedValue({
-      ok: true,
-      key: "ABCD-1234",
-      productId: "sample_album",
-      downloadUrl: "https://example.com/download",
-    } satisfies ValidateApiResponse),
+    validateKey: fn(
+      async (): Promise<ValidateApiResponse> => ({
+        ok: true,
+        key: "ABCD-1234",
+        productId: "sample_album",
+        downloadUrl: "https://example.com/download",
+      })
+    ),
   },
 };
 
 export const Invalid: Story = {
   args: {
     productId: "sample_album",
-    validateKey: fn().mockResolvedValue({
-      ok: false,
-      reason: "not_found",
-      message: "このコードは存在しません。",
-    } satisfies ValidateApiResponse),
+    validateKey: fn(
+      async (): Promise<ValidateApiResponse> => ({
+        ok: false,
+        reason: "not_found",
+        message: "このコードは存在しません。",
+      })
+    ),
   },
 };

--- a/app/components/DownloadSection/DownloadSection.tsx
+++ b/app/components/DownloadSection/DownloadSection.tsx
@@ -4,7 +4,7 @@ import { DownloadKey } from "../../utils/DownloadKey";
 const DEBOUNCE_MS = 700;
 
 type VerifyStatus = "idle" | "validating" | "verified" | "invalid";
-type ValidateApiResponse =
+export type ValidateApiResponse =
   | {
       ok: true;
       key: string;
@@ -17,16 +17,32 @@ type ValidateApiResponse =
       message: string;
     };
 
+export type ValidateKeyFn = (
+  downloadKey: string,
+  productId: string
+) => Promise<ValidateApiResponse>;
+
+const defaultValidateKey: ValidateKeyFn = async (downloadKey, productId) => {
+  const response = await fetch("/api/validate-key", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ downloadKey, productId }),
+  });
+  return response.json() as Promise<ValidateApiResponse>;
+};
+
 type DownloadSectionProps = {
   productId: string;
   title?: string;
   description?: string;
+  validateKey?: ValidateKeyFn;
 };
 
 export function DownloadSection({
   productId,
   title = "ダウンロード",
   description = "ダウンロードカード裏面に記載されたダウンロードコードをここに入力してください。",
+  validateKey = defaultValidateKey,
 }: DownloadSectionProps) {
   const [downloadKey, setDownloadKey] = useState("");
   const [verifyStatus, setVerifyStatus] = useState<VerifyStatus>("idle");
@@ -39,23 +55,12 @@ export function DownloadSection({
 
   const validateDownloadKey = async (displayKey: string, requestId: number) => {
     try {
-      const response = await fetch("/api/validate-key", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          downloadKey: displayKey,
-          productId,
-        }),
-      });
-
-      const data = (await response.json()) as ValidateApiResponse;
+      const data = await validateKey(displayKey, productId);
       if (requestIdRef.current !== requestId) {
         return;
       }
 
-      if (response.ok && data.ok) {
+      if (data.ok) {
         setVerifyStatus("verified");
         setVerifyMessage("コードを確認しました");
         setDownloadUrl(data.downloadUrl);
@@ -63,7 +68,7 @@ export function DownloadSection({
       }
 
       setVerifyStatus("invalid");
-      if (!data.ok && data.message) {
+      if (data.message) {
         setVerifyMessage(data.message);
       } else {
         setVerifyMessage("コードの検証に失敗しました。");

--- a/app/routes/home.stories.tsx
+++ b/app/routes/home.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { HomeView } from "./home";
+
+const meta: Meta<typeof HomeView> = {
+  title: "Routes/Home",
+  component: HomeView,
+};
+
+export default meta;
+type Story = StoryObj<typeof HomeView>;
+
+export const Default: Story = {
+  args: {
+    seed: 42,
+    now: new Date("2025-05-20T12:00:00+09:00"),
+    lastCommitAt: "2025-05-20T00:00:00Z",
+  },
+};
+
+export const NoLastCommit: Story = {
+  args: {
+    seed: 42,
+    now: new Date("2025-05-20T12:00:00+09:00"),
+    lastCommitAt: null,
+  },
+};

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -30,16 +30,22 @@ export function loader({ context }: Route.LoaderArgs) {
   };
 }
 
-export default function Home({ loaderData }: Route.ComponentProps) {
-  const lastUpdatedDate = loaderData.lastCommitAt
-    ? new Date(loaderData.lastCommitAt)
-    : null;
+export function HomeView({
+  seed,
+  now,
+  lastCommitAt,
+}: {
+  seed: number;
+  now: Date;
+  lastCommitAt: string | null;
+}) {
+  const lastUpdatedDate = lastCommitAt ? new Date(lastCommitAt) : null;
   const lastUpdatedText =
     lastUpdatedDate !== null && !Number.isNaN(lastUpdatedDate.getTime())
       ? toLocaleDateString(lastUpdatedDate)
       : null;
 
-  const random = new Random(loaderData.seed);
+  const random = new Random(seed);
   const featuredWorks = [...works]
     .sort((a, b) => b.releaseDate.getTime() - a.releaseDate.getTime())
     .slice(0, 4);
@@ -160,7 +166,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
         </p>
         <div className="grid gap-4">
           {featuredEvents.map((event) => (
-            <EventCard key={event.id} event={event} now={loaderData.now} />
+            <EventCard key={event.id} event={event} now={now} />
           ))}
         </div>
       </section>
@@ -216,5 +222,15 @@ export default function Home({ loaderData }: Route.ComponentProps) {
       </section>
       <BottomNav />
     </main>
+  );
+}
+
+export default function Home({ loaderData }: Route.ComponentProps) {
+  return (
+    <HomeView
+      seed={loaderData.seed}
+      now={loaderData.now}
+      lastCommitAt={loaderData.lastCommitAt}
+    />
   );
 }

--- a/app/utils/formats.test.ts
+++ b/app/utils/formats.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { toLocaleDateString, toLocaleString } from "./formats";
+
+describe("toLocaleDateString", () => {
+  it("年・月・日を含む文字列を返す", () => {
+    const result = toLocaleDateString(new Date("2025-03-15T00:00:00+09:00"));
+    expect(result).toMatch(/2025/);
+    expect(result).toMatch(/3/);
+    expect(result).toMatch(/15/);
+  });
+});
+
+describe("toLocaleString", () => {
+  it("年・月・日・時・分を含む文字列を返す", () => {
+    const result = toLocaleString(new Date("2025-03-15T12:30:00+09:00"));
+    expect(result).toMatch(/2025/);
+    expect(result).toMatch(/3/);
+    expect(result).toMatch(/15/);
+    expect(result).toMatch(/12/);
+    expect(result).toMatch(/30/);
+  });
+});

--- a/app/utils/paths.test.ts
+++ b/app/utils/paths.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildOGMeta,
+  getEventPath,
+  getWorkPath,
+  normalizeLegacyId,
+  SITE_URL,
+} from "./paths";
+import type { Event, Work } from "~/types";
+
+const albumWork: Work = {
+  type: "album",
+  id: "test_album",
+  title: "テストアルバム",
+  titlePrefix: "",
+  description: "",
+  tags: [],
+  credits: [],
+  releaseDate: new Date("2025-01-01"),
+  links: [],
+  jacketImageUrl: "",
+  tracks: [],
+};
+
+const performanceEvent: Event = {
+  type: "performance",
+  id: "test_perf",
+  title: "テストイベント",
+  tags: [],
+  date: new Date("2025-01-01"),
+  links: [],
+};
+
+describe("normalizeLegacyId", () => {
+  it("ハイフンをアンダースコアに変換する", () => {
+    expect(normalizeLegacyId("foo-bar-baz")).toBe("foo_bar_baz");
+  });
+
+  it("ハイフンがない場合はそのまま返す", () => {
+    expect(normalizeLegacyId("foobar")).toBe("foobar");
+  });
+});
+
+describe("getWorkPath", () => {
+  it("album の正しいパスを返す", () => {
+    expect(getWorkPath(albumWork)).toBe("/works/albums/test_album");
+  });
+
+  it("music の正しいパスを返す", () => {
+    const work: Work = { ...albumWork, type: "music", id: "test_music" };
+    expect(getWorkPath(work)).toBe("/works/musics/test_music");
+  });
+
+  it("game の正しいパスを返す", () => {
+    const work: Work = {
+      ...albumWork,
+      type: "game",
+      id: "test_game",
+      tracks: undefined,
+    };
+    expect(getWorkPath(work)).toBe("/works/games/test_game");
+  });
+
+  it("other の正しいパスを返す", () => {
+    const work: Work = {
+      ...albumWork,
+      type: "other",
+      id: "test_other",
+      tracks: undefined,
+    };
+    expect(getWorkPath(work)).toBe("/works/others/test_other");
+  });
+});
+
+describe("getEventPath", () => {
+  it("performance の正しいパスを返す", () => {
+    expect(getEventPath(performanceEvent)).toBe(
+      "/events/performances/test_perf"
+    );
+  });
+
+  it("exhibition の正しいパスを返す", () => {
+    const event: Event = {
+      ...performanceEvent,
+      type: "exhibition",
+      id: "test_exh",
+    };
+    expect(getEventPath(event)).toBe("/events/exhibitions/test_exh");
+  });
+});
+
+describe("buildOGMeta", () => {
+  it("title なしの場合は「竹馬あお」のみになる", () => {
+    const meta = buildOGMeta({ path: "/" });
+    const titleEntry = meta.find((m) => "title" in m);
+    expect(titleEntry).toEqual({ title: "竹馬あお" });
+  });
+
+  it("title を指定すると「タイトル - 竹馬あお」になる", () => {
+    const meta = buildOGMeta({ path: "/works", title: ["作品"] });
+    const titleEntry = meta.find((m) => "title" in m);
+    expect(titleEntry).toEqual({ title: "作品 - 竹馬あお" });
+  });
+
+  it("og:url が SITE_URL + path になる", () => {
+    const meta = buildOGMeta({ path: "/works" });
+    const ogUrl = meta.find((m) => "property" in m && m.property === "og:url");
+    expect(ogUrl).toMatchObject({ content: `${SITE_URL}/works` });
+  });
+});

--- a/app/utils/random.test.ts
+++ b/app/utils/random.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { Random } from "./random";
+
+describe("Random", () => {
+  it("同じシードは同じ乱数列を生成する", () => {
+    const r1 = new Random(42);
+    const r2 = new Random(42);
+    expect(r1.next()).toBe(r2.next());
+    expect(r1.next()).toBe(r2.next());
+    expect(r1.next()).toBe(r2.next());
+  });
+
+  it("異なるシードは異なる乱数列を生成する", () => {
+    const r1 = new Random(1);
+    const r2 = new Random(2);
+    expect(r1.next()).not.toBe(r2.next());
+  });
+
+  it("nextInt は min 以上 max 以下の整数を返す", () => {
+    const r = new Random(123);
+    for (let i = 0; i < 100; i++) {
+      const val = r.nextInt(0, 9);
+      expect(val).toBeGreaterThanOrEqual(0);
+      expect(val).toBeLessThanOrEqual(9);
+    }
+  });
+
+  it("nextInt(n, n) は常に n を返す", () => {
+    const r = new Random(999);
+    for (let i = 0; i < 10; i++) {
+      expect(r.nextInt(5, 5)).toBe(5);
+    }
+  });
+});

--- a/app/utils/searches.test.ts
+++ b/app/utils/searches.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { normalizeText } from "./searches";
+
+describe("normalizeText", () => {
+  it("小文字に変換する", () => {
+    expect(normalizeText("Hello")).toBe("hello");
+  });
+
+  it("前後の空白を除去する", () => {
+    expect(normalizeText("  hello  ")).toBe("hello");
+  });
+
+  it("空文字列はそのまま返す", () => {
+    expect(normalizeText("")).toBe("");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
 
-// Storybook の addon-vitest とは別に、workers/ の unit テスト用の設定
 export default defineConfig({
+  plugins: [tsconfigPaths()],
   test: {
-    include: ["workers/**/*.test.ts"],
+    include: ["workers/**/*.test.ts", "app/**/*.test.ts"],
     environment: "node",
   },
 });


### PR DESCRIPTION
## Summary

- `DatePickerInput` の `parseDate`/`formatDate`/`applyMask` を `dateUtils.ts` に切り出しテスト追加
- `DownloadSection` の fetch 呼び出しを `validateKey` prop に DI 化し、`stories.tsx` を追加（`fn()` でモック）
- `HomeView` を named export に切り出し `home.stories.tsx` を追加
- `utils/formats`, `paths`, `searches`, `random` のテストを追加
- `vitest.config.ts` に `app/**/*.test.ts` を追加
- `CLAUDE.md` に `pnpm test` コマンドを追記

Closes #129

## Test plan

- [x] `pnpm test` → 42 tests pass
- [x] `pnpm build` が通ること（CI で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)