### PR TITLE
ダウンロード機能の改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,6 @@ Every component in `app/components/` has a colocated `.stories.tsx`. Route files
 | `aotakeuma_contents` | R2     | Stores downloadable `.zip` files  |
 | `aotakeuma_keys`     | KV     | Stores download key records       |
 | `SIGNED_URL_SECRET`  | Secret | HMAC key for signed download URLs |
-| `LAST_DEPLOYED_AT`   | Var    | Injected at deploy time           |
 
 Run `pnpm typegen` after changing `wrangler.jsonc` to regenerate `worker-configuration.d.ts`.
+シークレットは `wrangler types` で自動生成されないため、`workers/env-secrets.d.ts` で手動拡張している。シークレットを追加・変更した際はこのファイルも更新すること。

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ pnpm deploy
 
 週に一回走るので、なんかいい感じにマージする。
 
+## ダウンロード機能運用
+
+- `pnpm dev:remote` で admin 機能にアクセス
+- `R2 アップロード` タブでアルバムの {workId}.zip をアップロード
+- `キー発行` タブで、Product ID のところには {workId} を記入し、発行
+- contents 以下の {workId} の定義で、downloadEnabled を true にする
+
 ---
 
 ## 開発モードの仕組み

--- a/app/components/DownloadSection/DownloadSection.tsx
+++ b/app/components/DownloadSection/DownloadSection.tsx
@@ -41,7 +41,7 @@ type DownloadSectionProps = {
 export function DownloadSection({
   productId,
   title = "ダウンロード",
-  description = "ダウンロードカード裏面に記載されたダウンロードコードをここに入力してください。",
+  description = "頒布物裏面に記載されたダウンロードコードをここに入力してください。",
   validateKey = defaultValidateKey,
 }: DownloadSectionProps) {
   const [downloadKey, setDownloadKey] = useState("");
@@ -144,20 +144,16 @@ export function DownloadSection({
       <div className="space-y-1">
         <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
         <p className="text-sm text-slate-600">{description}</p>
-        <p className="text-xs text-slate-600">
-          ※マジで急ピッチで作ったのでもし不具合があったら教えてください (03/29
-          朝)
-        </p>
       </div>
 
-      <form className="space-y-4" onSubmit={onSubmit}>
-        <div className="space-y-2">
-          <label
-            htmlFor={inputId}
-            className="text-sm font-semibold text-slate-900"
-          >
-            ダウンロードコード
-          </label>
+      <form className="space-y-2" onSubmit={onSubmit}>
+        <label
+          htmlFor={inputId}
+          className="text-sm font-semibold text-slate-900"
+        >
+          ダウンロードコード
+        </label>
+        <div className="flex flex-col gap-2 md:flex-row">
           <input
             type="text"
             id={inputId}
@@ -165,43 +161,41 @@ export function DownloadSection({
             value={downloadKey}
             onChange={onChangeDownloadKey}
             className={[
-              "w-full px-4 py-2 rounded-lg border border-slate-300 bg-white text-slate-900 placeholder-slate-400",
+              "min-w-0 flex-1 px-4 py-2 rounded-lg border border-slate-300 bg-white text-slate-900 placeholder-slate-400",
               "focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20",
               "transition-all duration-150",
             ].join(" ")}
-            placeholder="ダウンロードコードを入力してください"
+            placeholder="XXXX-XXXX"
             autoComplete="off"
             inputMode="text"
             aria-describedby={statusId}
           />
-
-          <div id={statusId} className="min-h-6">
-            {verifyStatus === "validating" ? (
-              <p className="text-sm text-slate-600">コードを確認中...</p>
-            ) : null}
-
-            {verifyStatus === "verified" ? (
-              <p className="text-sm font-semibold text-green-700">
-                ✓ {verifyMessage}
-              </p>
-            ) : null}
-
-            {verifyStatus === "invalid" ? (
-              <p className="text-sm font-semibold text-red-700">
-                {verifyMessage}
-              </p>
-            ) : null}
-          </div>
+          <button
+            type="submit"
+            disabled={verifyStatus !== "verified" || !downloadUrl}
+            className="w-full md:w-auto shrink-0 px-6 py-2 rounded-lg bg-primary text-primary-950 font-semibold enabled:hover:shadow-lg enabled:hover:scale-101 enabled:active:scale-99 transition-all duration-150 disabled:opacity-70 disabled:cursor-not-allowed"
+          >
+            ダウンロード
+          </button>
         </div>
 
-        <button
-          type="submit"
-          disabled={verifyStatus !== "verified" || !downloadUrl}
-          className="w-full px-6 py-3 rounded-lg bg-primary text-primary-950 font-semibold enabled:hover:shadow-lg enabled:hover:scale-101 enabled:active:scale-99 transition-all duration-150 disabled:opacity-70 disabled:cursor-not-allowed"
-        >
-          {/* TODO: マジでスタイル直す */}
-          ダウンロード
-        </button>
+        <div id={statusId} className="min-h-5">
+          {verifyStatus === "validating" ? (
+            <p className="text-sm text-slate-600">コードを確認中...</p>
+          ) : null}
+
+          {verifyStatus === "verified" ? (
+            <p className="text-sm font-semibold text-green-700">
+              ✓ {verifyMessage}
+            </p>
+          ) : null}
+
+          {verifyStatus === "invalid" ? (
+            <p className="text-sm font-semibold text-red-700">
+              {verifyMessage}
+            </p>
+          ) : null}
+        </div>
       </form>
     </section>
   );

--- a/app/contents/works/albums/digimoca.ts
+++ b/app/contents/works/albums/digimoca.ts
@@ -41,4 +41,5 @@ export const digimoca: Album = {
     niconicoUrl: "https://www.nicovideo.jp/watch/sm45443516",
     bilibiliUrl: "https://www.bilibili.com/video/BV1s6n8zFEwr",
   },
+  downloadEnabled: true,
 };

--- a/app/contents/works/albums/kisetsu.ts
+++ b/app/contents/works/albums/kisetsu.ts
@@ -38,4 +38,5 @@ export const kisetsu: Album = {
     niconicoUrl: "https://www.nicovideo.jp/watch/sm45072233",
     bilibiliUrl: "https://www.bilibili.com/video/BV1FNTezYEYJ",
   },
+  downloadEnabled: true,
 };

--- a/app/contents/works/albums/tnftep1.ts
+++ b/app/contents/works/albums/tnftep1.ts
@@ -46,4 +46,5 @@ export const tnftep1: Album = {
     niconicoUrl: "https://www.nicovideo.jp/watch/sm44599383",
     bilibiliUrl: "https://www.bilibili.com/video/BV158FXePEZ9",
   },
+  downloadEnabled: true,
 };

--- a/app/contents/works/albums/ubugoe.ts
+++ b/app/contents/works/albums/ubugoe.ts
@@ -74,4 +74,5 @@ export const ubugoe: Album = {
     niconicoUrl: "https://www.nicovideo.jp/watch/sm44104181",
     bilibiliUrl: "https://www.bilibili.com/video/BV1nNtgetEoV",
   },
+  downloadEnabled: true,
 };

--- a/app/routes/admin/keys/new.tsx
+++ b/app/routes/admin/keys/new.tsx
@@ -3,6 +3,7 @@ import { Form, redirect, useNavigation } from "react-router";
 import type { Route } from "./+types/new";
 import { api } from "../../../../workers/api/router";
 import { DatePickerInput } from "../../../components/DatePickerInput/DatePickerInput";
+import { normalizeDownloadKey } from "../../../../workers/api/models/downloadKey";
 
 export function loader() {
   const defaultExpiry = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)
@@ -13,16 +14,29 @@ export function loader() {
 
 export async function action({ request, context }: Route.ActionArgs) {
   const fd = await request.formData();
-  const count = Number(fd.get("count") ?? 1);
+  const mode = String(fd.get("mode") ?? "random");
   const productId = String(fd.get("productId") ?? "");
   const expiresAt = String(fd.get("expiresAt") ?? "");
   const maxUseCount = Number(fd.get("maxUseCount") ?? 1);
+
+  let body: object;
+  if (mode === "manual") {
+    const raw = String(fd.get("keys") ?? "");
+    const keys = raw
+      .split("\n")
+      .map((l) => normalizeDownloadKey(l.trim()))
+      .filter((k) => k.length > 0);
+    body = { keys, productId, expiresAt, maxUseCount, count: keys.length };
+  } else {
+    const count = Number(fd.get("count") ?? 1);
+    body = { count, productId, expiresAt, maxUseCount };
+  }
 
   await api.fetch(
     new Request(new URL("/api/admin/keys", request.url), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ count, productId, expiresAt, maxUseCount }),
+      body: JSON.stringify(body),
     }),
     context.cloudflare.env
   );
@@ -30,27 +44,114 @@ export async function action({ request, context }: Route.ActionArgs) {
   return redirect("/admin/keys");
 }
 
+function parseManualKeys(raw: string): {
+  keys: string[];
+  errors: string[];
+} {
+  const lines = raw.split("\n").filter((l) => l.trim() !== "");
+  const keys: string[] = [];
+  const errors: string[] = [];
+  const seen = new Set<string>();
+
+  for (const line of lines) {
+    const normalized = normalizeDownloadKey(line.trim());
+    if (normalized.length !== 8) {
+      errors.push(
+        `"${line.trim()}" は正規化後 ${normalized.length} 文字になるため無効です（8文字必要）`
+      );
+    } else if (seen.has(normalized)) {
+      errors.push(`"${line.trim()}" は重複しています`);
+    } else {
+      seen.add(normalized);
+      keys.push(normalized);
+    }
+  }
+
+  return { keys, errors };
+}
+
 export default function KeysNew({ loaderData }: Route.ComponentProps) {
   const { defaultExpiry } = loaderData;
   const [expiresAt, setExpiresAt] = useState(defaultExpiry);
+  const [mode, setMode] = useState<"random" | "manual">("random");
+  const [manualRaw, setManualRaw] = useState("");
   const nav = useNavigation();
   const submitting = nav.state === "submitting";
+
+  const { keys: parsedKeys, errors: parseErrors } = parseManualKeys(manualRaw);
+  const manualValid =
+    manualRaw.trim() !== "" &&
+    parseErrors.length === 0 &&
+    parsedKeys.length > 0;
 
   return (
     <div className="max-w-lg">
       <h1 className="text-2xl font-bold text-blue-400 mb-6">キー発行</h1>
       <Form method="post" className="flex flex-col gap-4">
-        <label className="flex flex-col gap-1">
-          <span className="text-gray-400 text-sm">発行枚数</span>
-          <input
-            type="number"
-            name="count"
-            defaultValue={1}
-            min={1}
-            max={100}
-            className="bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white"
-          />
-        </label>
+        <input type="hidden" name="mode" value={mode} />
+
+        {/* モード切替 */}
+        <div className="flex rounded overflow-hidden border border-gray-700 w-fit">
+          <button
+            type="button"
+            onClick={() => setMode("random")}
+            className={`px-4 py-2 text-sm ${mode === "random" ? "bg-blue-700 text-white" : "bg-gray-900 text-gray-400 hover:text-white"}`}
+          >
+            ランダム生成
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("manual")}
+            className={`px-4 py-2 text-sm border-l border-gray-700 ${mode === "manual" ? "bg-blue-700 text-white" : "bg-gray-900 text-gray-400 hover:text-white"}`}
+          >
+            手動入力
+          </button>
+        </div>
+
+        {/* ランダム生成モード */}
+        {mode === "random" && (
+          <label className="flex flex-col gap-1">
+            <span className="text-gray-400 text-sm">発行枚数</span>
+            <input
+              type="number"
+              name="count"
+              defaultValue={1}
+              min={1}
+              max={100}
+              className="bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white"
+            />
+          </label>
+        )}
+
+        {/* 手動入力モード */}
+        {mode === "manual" && (
+          <div className="flex flex-col gap-1">
+            <span className="text-gray-400 text-sm">既存キー（1行1キー）</span>
+            <textarea
+              name="keys"
+              rows={6}
+              value={manualRaw}
+              onChange={(e) => setManualRaw(e.target.value)}
+              placeholder={"ABCD1234\nEFGH5678"}
+              className="bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white font-mono text-sm resize-y"
+            />
+            {manualRaw.trim() !== "" && (
+              <div className="text-sm mt-1 flex flex-col gap-1">
+                {parseErrors.map((err, i) => (
+                  <p key={i} className="text-red-400">
+                    {err}
+                  </p>
+                ))}
+                {parseErrors.length === 0 && parsedKeys.length > 0 && (
+                  <p className="text-green-400">
+                    {parsedKeys.length} 件のキーが有効です
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
         <label className="flex flex-col gap-1">
           <span className="text-gray-400 text-sm">Product ID</span>
           <input
@@ -77,7 +178,7 @@ export default function KeysNew({ loaderData }: Route.ComponentProps) {
         </label>
         <button
           type="submit"
-          disabled={submitting}
+          disabled={submitting || (mode === "manual" && !manualValid)}
           className="bg-blue-700 hover:bg-blue-600 disabled:opacity-50 text-white px-4 py-2 rounded mt-2"
         >
           {submitting ? "発行中..." : "発行する"}

--- a/app/routes/admin/upload.tsx
+++ b/app/routes/admin/upload.tsx
@@ -1,44 +1,118 @@
-import { Form, useNavigation, useActionData } from "react-router";
-import type { Route } from "./+types/upload";
-import { api } from "../../../workers/api/router";
+import { useRef, useState } from "react";
 
-export async function action({ request, context }: Route.ActionArgs) {
-  const fd = await request.formData();
-  const res = await api.fetch(
-    new Request(new URL("/api/admin/upload", request.url), {
-      method: "POST",
-      body: fd,
-    }),
-    context.cloudflare.env
-  );
-  const result = await res.json<{
-    key?: string;
-    size?: number;
-    error?: string;
-  }>();
-  return result;
-}
+const CHUNK_SIZE = 50 * 1024 * 1024; // 50MB — Workers の 100MB 制限より安全側
+
+type UploadState =
+  | { status: "idle" }
+  | { status: "uploading"; progress: number; partsDone: number; total: number }
+  | { status: "done"; key: string; size: number }
+  | { status: "error"; message: string };
 
 export default function Upload() {
-  const nav = useNavigation();
-  const actionData = useActionData<typeof action>();
-  const submitting = nav.state === "submitting";
+  const fileRef = useRef<HTMLInputElement>(null);
+  const keyRef = useRef<HTMLInputElement>(null);
+  const [state, setState] = useState<UploadState>({ status: "idle" });
+
+  const handleUpload = async () => {
+    const file = fileRef.current?.files?.[0];
+    if (!file) return;
+    const key = keyRef.current?.value.trim() || file.name;
+
+    const totalParts = Math.ceil(file.size / CHUNK_SIZE);
+    setState({
+      status: "uploading",
+      progress: 0,
+      partsDone: 0,
+      total: totalParts,
+    });
+
+    let uploadId = "";
+    let uploadKey = "";
+    try {
+      // 1. initiate
+      const initRes = await fetch("/api/admin/upload/initiate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key }),
+      });
+      if (!initRes.ok)
+        throw new Error(`Initiate failed: ${await initRes.text()}`);
+      ({ uploadId, key: uploadKey } = await initRes.json<{
+        uploadId: string;
+        key: string;
+      }>());
+
+      // 2. upload parts
+      const uploadedParts: { partNumber: number; etag: string }[] = [];
+      for (let i = 0; i < totalParts; i++) {
+        const chunk = file.slice(i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE);
+        const params = new URLSearchParams({
+          key: uploadKey,
+          uploadId,
+          partNumber: String(i + 1),
+        });
+        const partRes = await fetch(`/api/admin/upload/part?${params}`, {
+          method: "PUT",
+          body: chunk,
+        });
+        if (!partRes.ok)
+          throw new Error(`Part ${i + 1} failed: ${await partRes.text()}`);
+        const { partNumber, etag } = await partRes.json<{
+          partNumber: number;
+          etag: string;
+        }>();
+        uploadedParts.push({ partNumber, etag });
+        setState({
+          status: "uploading",
+          progress: Math.round(((i + 1) / totalParts) * 100),
+          partsDone: i + 1,
+          total: totalParts,
+        });
+      }
+
+      // 3. complete
+      const completeRes = await fetch("/api/admin/upload/complete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          key: uploadKey,
+          uploadId,
+          parts: uploadedParts,
+        }),
+      });
+      if (!completeRes.ok)
+        throw new Error(`Complete failed: ${await completeRes.text()}`);
+      const { key: doneKey, size } = await completeRes.json<{
+        key: string;
+        size: number;
+      }>();
+      setState({ status: "done", key: doneKey, size });
+    } catch (err) {
+      // abort if we have an uploadId
+      if (uploadId && uploadKey) {
+        await fetch("/api/admin/upload/abort", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ key: uploadKey, uploadId }),
+        }).catch(() => {});
+      }
+      setState({ status: "error", message: String(err) });
+    }
+  };
+
+  const uploading = state.status === "uploading";
 
   return (
     <div className="max-w-lg">
       <h1 className="text-2xl font-bold text-blue-400 mb-6">R2 アップロード</h1>
-      <Form
-        method="post"
-        encType="multipart/form-data"
-        className="flex flex-col gap-4"
-      >
+      <div className="flex flex-col gap-4">
         <label className="flex flex-col gap-1">
           <span className="text-gray-400 text-sm">ファイル</span>
           <input
+            ref={fileRef}
             type="file"
-            name="file"
-            required
-            className="text-white file:bg-gray-700 file:border-0 file:text-white file:px-3 file:py-1 file:rounded file:mr-3"
+            disabled={uploading}
+            className="text-white file:bg-gray-700 file:border-0 file:text-white file:px-3 file:py-1 file:rounded file:mr-3 disabled:opacity-50"
           />
         </label>
         <label className="flex flex-col gap-1">
@@ -46,30 +120,47 @@ export default function Upload() {
             R2 キー（省略時はファイル名）
           </span>
           <input
+            ref={keyRef}
             type="text"
-            name="key"
+            disabled={uploading}
             placeholder="例: yohkoh.zip"
-            className="bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white placeholder-gray-600"
+            className="bg-gray-900 border border-gray-700 rounded px-3 py-2 text-white placeholder-gray-600 disabled:opacity-50"
           />
         </label>
         <button
-          type="submit"
-          disabled={submitting}
+          onClick={handleUpload}
+          disabled={uploading}
           className="bg-blue-700 hover:bg-blue-600 disabled:opacity-50 text-white px-4 py-2 rounded mt-2"
         >
-          {submitting ? "アップロード中..." : "アップロード"}
+          {uploading ? "アップロード中..." : "アップロード"}
         </button>
-      </Form>
 
-      {actionData && (
-        <div
-          className={`mt-6 p-4 rounded text-sm ${actionData.error ? "bg-red-900 text-red-300" : "bg-green-900 text-green-300"}`}
-        >
-          {actionData.error
-            ? `エラー: ${actionData.error}`
-            : `完了: ${actionData.key} (${((actionData.size ?? 0) / 1024).toFixed(1)} KB)`}
-        </div>
-      )}
+        {state.status === "uploading" && (
+          <div className="flex flex-col gap-2">
+            <div className="w-full bg-gray-800 rounded-full h-2">
+              <div
+                className="bg-blue-500 h-2 rounded-full transition-all duration-300"
+                style={{ width: `${state.progress}%` }}
+              />
+            </div>
+            <p className="text-gray-400 text-sm">
+              {state.partsDone} / {state.total} パート完了（{state.progress}%）
+            </p>
+          </div>
+        )}
+
+        {state.status === "done" && (
+          <div className="mt-2 p-4 rounded text-sm bg-green-900 text-green-300">
+            完了: {state.key}（{(state.size / 1024 / 1024).toFixed(1)} MB）
+          </div>
+        )}
+
+        {state.status === "error" && (
+          <div className="mt-2 p-4 rounded text-sm bg-red-900 text-red-300">
+            エラー: {state.message}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/routes/works/album.stories.tsx
+++ b/app/routes/works/album.stories.tsx
@@ -11,9 +11,30 @@ const meta: Meta<typeof AlbumView> = {
 export default meta;
 type Story = StoryObj<typeof AlbumView>;
 
+// ubugoe は m3_2025_autumn (2025-10-26) に頒布されている
+const ubugoe = albums.find((a) => a.id === "ubugoe")!;
+
 export const Default: Story = {
   args: {
     album: albums[0],
     now: new Date(),
+  },
+};
+
+// DownloadSection がタイトル直下に表示される（即売会から2日後）
+export const DownloadTopRecentExhibition: Story = {
+  name: "Download: 先頭（直近7日に即売会あり）",
+  args: {
+    album: ubugoe,
+    now: new Date("2025-10-28"),
+  },
+};
+
+// DownloadSection がページ末尾に表示される（即売会から7日超）
+export const DownloadBottomOldExhibition: Story = {
+  name: "Download: 末尾（直近7日に即売会なし）",
+  args: {
+    album: ubugoe,
+    now: new Date("2026-05-20"),
   },
 };

--- a/app/routes/works/album.tsx
+++ b/app/routes/works/album.tsx
@@ -40,6 +40,14 @@ export function AlbumView({ album, now }: { album: Album; now: Date }) {
     )
     .sort((a, b) => b.date.getTime() - a.date.getTime());
 
+  const RECENT_DAYS = 7;
+  const recentCutoff = new Date(
+    now.getTime() - RECENT_DAYS * 24 * 60 * 60 * 1000
+  );
+  const hasRecentExhibition = exhibitionsWithAlbum.some(
+    (e) => e.date >= recentCutoff && e.date <= now
+  );
+
   return (
     <main>
       <Banner src={album.jacketImageUrl} alt={`${album.title}のジャケット`} />
@@ -64,8 +72,7 @@ export function AlbumView({ album, now }: { album: Album; now: Date }) {
           </p>
         </section>
 
-        {/* TODO: リリース日からnヶ月の場合は最初、else最後に置くようにする */}
-        {album.downloadEnabled ? (
+        {hasRecentExhibition && album.downloadEnabled ? (
           <DownloadSection productId={album.id} />
         ) : null}
 
@@ -126,6 +133,10 @@ export function AlbumView({ album, now }: { album: Album; now: Date }) {
             <h2 className="text-lg font-semibold text-slate-900">動画</h2>
             <VideoIframe video={album.video} />
           </section>
+        ) : null}
+
+        {!hasRecentExhibition && album.downloadEnabled ? (
+          <DownloadSection productId={album.id} />
         ) : null}
       </div>
     </main>

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -8,6 +8,7 @@ import { configs as storybookConfigs } from "eslint-plugin-storybook";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
+  // TODO: tseslintConfigs.recommendedTypeChecked にしたい！
   tseslintConfigs.recommended,
   pluginImport.flatConfigs.recommended,
   pluginImport.flatConfigs.typescript,

--- a/workers/api/admin/controllers/keys.ts
+++ b/workers/api/admin/controllers/keys.ts
@@ -29,16 +29,19 @@ export const getKey = async (c: Context<{ Bindings: Env }>) => {
 };
 
 export const createKeys = async (c: Context<{ Bindings: Env }>) => {
-  const { count, productId, expiresAt, maxUseCount } = await c.req.json<{
+  const { count, productId, expiresAt, maxUseCount, keys } = await c.req.json<{
     count: number;
     productId: string;
     expiresAt: string;
     maxUseCount: number;
+    keys?: string[];
   }>();
 
+  const keysToCreate =
+    keys ?? Array.from({ length: count }, generateDownloadKey);
+
   const created: string[] = [];
-  for (let i = 0; i < count; i++) {
-    const key = generateDownloadKey();
+  for (const key of keysToCreate) {
     const record: DownloadKeyRecord = {
       productId,
       isActive: true,

--- a/workers/api/admin/controllers/multipartUpload.ts
+++ b/workers/api/admin/controllers/multipartUpload.ts
@@ -1,0 +1,38 @@
+import type { Context } from "hono";
+
+export const initiateUpload = async (c: Context<{ Bindings: Env }>) => {
+  const { key } = await c.req.json<{ key: string }>();
+  const upload = await c.env.aotakeuma_contents.createMultipartUpload(key);
+  return c.json({ uploadId: upload.uploadId, key: upload.key });
+};
+
+export const uploadPart = async (c: Context<{ Bindings: Env }>) => {
+  const key = c.req.query("key") ?? "";
+  const uploadId = c.req.query("uploadId") ?? "";
+  const partNumber = Number(c.req.query("partNumber"));
+  const upload = c.env.aotakeuma_contents.resumeMultipartUpload(key, uploadId);
+  const body = await c.req.arrayBuffer();
+  const part = await upload.uploadPart(partNumber, body);
+  return c.json({ partNumber: part.partNumber, etag: part.etag });
+};
+
+export const completeUpload = async (c: Context<{ Bindings: Env }>) => {
+  const { key, uploadId, parts } = await c.req.json<{
+    key: string;
+    uploadId: string;
+    parts: { partNumber: number; etag: string }[];
+  }>();
+  const upload = c.env.aotakeuma_contents.resumeMultipartUpload(key, uploadId);
+  const object = await upload.complete(parts);
+  return c.json({ key: object.key, size: object.size });
+};
+
+export const abortUpload = async (c: Context<{ Bindings: Env }>) => {
+  const { key, uploadId } = await c.req.json<{
+    key: string;
+    uploadId: string;
+  }>();
+  const upload = c.env.aotakeuma_contents.resumeMultipartUpload(key, uploadId);
+  await upload.abort();
+  return c.json({ ok: true });
+};

--- a/workers/api/admin/router.ts
+++ b/workers/api/admin/router.ts
@@ -1,6 +1,12 @@
 import { Hono } from "hono";
 import { listKeys, getKey, createKeys, updateKey } from "./controllers/keys";
 import { uploadContent } from "./controllers/upload";
+import {
+  initiateUpload,
+  uploadPart,
+  completeUpload,
+  abortUpload,
+} from "./controllers/multipartUpload";
 
 const adminRouter = new Hono<{ Bindings: Env }>();
 
@@ -9,5 +15,9 @@ adminRouter.post("/keys", createKeys);
 adminRouter.get("/keys/:key", getKey);
 adminRouter.patch("/keys/:key", updateKey);
 adminRouter.post("/upload", uploadContent);
+adminRouter.post("/upload/initiate", initiateUpload);
+adminRouter.put("/upload/part", uploadPart);
+adminRouter.post("/upload/complete", completeUpload);
+adminRouter.delete("/upload/abort", abortUpload);
 
 export { adminRouter };

--- a/workers/env-secrets.d.ts
+++ b/workers/env-secrets.d.ts
@@ -1,0 +1,5 @@
+// worker-configuration.d.ts は pnpm typegen で自動生成されるため、
+// wrangler secret で管理するシークレットの型はここで手動拡張する
+interface Env {
+  SIGNED_URL_SECRET: string;
+}


### PR DESCRIPTION
## Summary

- **キー手動発行**: admin のキー発行フォームに「ランダム生成 / 手動入力」トグルを追加。既存キーを1行1キーで貼り付け可能になり、正規化後8文字未満・重複はバリデーションエラーを表示
- **大容量アップロード対応**: R2 binding のマルチパートアップロード（50MB/パート）を使い、Workers の 100MB リクエスト制限を回避。プログレスバー・エラー時の自動 abort も実装
- **DownloadSection UI改善**: 入力欄とボタンを横並び（md以上）に変更。認証メッセージを下行に配置。文言も整備
- **DownloadSection 表示位置**: 直近7日以内に即売会がある場合はタイトル直下、そうでない場合はページ末尾に表示
- **4アルバムのダウンロード機能を有効化**: ubugoe / digimoca / kisetsu / tnftep1

## Test plan

- [ ] `pnpm dev:remote` で admin → キー発行：ランダム生成・手動入力の両モード動作確認
- [ ] 手動入力：不正キー・重複キーでバリデーションエラーが出ることを確認
- [ ] `pnpm dev:remote` で admin → R2 アップロード：100MB超のファイルをアップロードできることを確認
- [ ] DownloadSection の入力欄・ボタン横並び（PC）・縦並び（スマホ）を確認
- [ ] Storybook「Routes/Works/Album」で DownloadSection の先頭・末尾表示の両パターンを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)